### PR TITLE
Add infrastructure KMS key

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,17 @@ This project creates and manages resources within an AWS account for infrastruct
 
 ## Providers
 
-No providers.
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.24.0 |
 
 ## Resources
 
-No resources.
+| Name | Type |
+|------|------|
+| [aws_kms_alias.infrastructure](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
+| [aws_kms_key.infrastructure](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 
 ## Inputs
 
@@ -27,6 +33,7 @@ No resources.
 |------|-------------|------|---------|:--------:|
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region in which to launch resources | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment name to be used as part of the resource prefix | `string` | n/a | yes |
+| <a name="input_infrastructure_kms_encryption"></a> [infrastructure\_kms\_encryption](#input\_infrastructure\_kms\_encryption) | Enable infrastructure KMS encryption. This will create a single KMS key to be used across all resources that support KMS encryption. | `bool` | n/a | yes |
 | <a name="input_infrastructure_name"></a> [infrastructure\_name](#input\_infrastructure\_name) | The infrastructure name to be used as part of the resource prefix | `string` | n/a | yes |
 | <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name to be used as a prefix for all resources | `string` | n/a | yes |
 

--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,1 @@
+data "aws_caller_identity" "current" {}

--- a/kms-infrastructure.tf
+++ b/kms-infrastructure.tf
@@ -1,0 +1,29 @@
+resource "aws_kms_key" "infrastructure" {
+  count = local.infrastructure_kms_encryption ? 1 : 0
+
+  description             = "${local.resource_prefix} infrastructure kms key"
+  deletion_window_in_days = 30
+  enable_key_rotation     = true
+
+  policy = templatefile(
+    "${path.root}/policies/kms-key-policy.json.tpl",
+    {
+      statement = <<EOT
+      [
+      ${templatefile("${path.root}/policies/kms-key-policy-statements/root-allow-all.json.tpl",
+      {
+        aws_account_id = local.aws_account_id
+      }
+  )}
+      ]
+      EOT
+}
+)
+}
+
+resource "aws_kms_alias" "infrastructure" {
+  count = local.infrastructure_kms_encryption ? 1 : 0
+
+  name          = "alias/${local.resource_prefix}-infrastructure"
+  target_key_id = aws_kms_key.infrastructure[0].key_id
+}

--- a/locals.tf
+++ b/locals.tf
@@ -3,7 +3,10 @@ locals {
   infrastructure_name = var.infrastructure_name
   environment         = var.environment
   aws_region          = var.aws_region
+  aws_account_id      = data.aws_caller_identity.current.account_id
   resource_prefix     = "${var.project_name}-${var.infrastructure_name}-${var.environment}"
+
+  infrastructure_kms_encryption = var.infrastructure_kms_encryption
 
   default_tags = {
     Project        = local.project_name,

--- a/policies/kms-key-policy-statements/root-allow-all.json.tpl
+++ b/policies/kms-key-policy-statements/root-allow-all.json.tpl
@@ -1,0 +1,8 @@
+{
+  "Effect": "Allow",
+  "Principal": {
+    "AWS": "arn:aws:iam::${aws_account_id}:root"
+  },
+  "Action": "kms:*",
+  "Resource": "*"
+}

--- a/policies/kms-key-policy.json.tpl
+++ b/policies/kms-key-policy.json.tpl
@@ -1,0 +1,5 @@
+{
+  "Version": "2012-10-17",
+  "Id": "key-permissions",
+  "Statement": ${statement}
+}

--- a/variables.tf
+++ b/variables.tf
@@ -17,3 +17,8 @@ variable "aws_region" {
   description = "AWS region in which to launch resources"
   type        = string
 }
+
+variable "infrastructure_kms_encryption" {
+  description = "Enable infrastructure KMS encryption. This will create a single KMS key to be used across all resources that support KMS encryption."
+  type        = bool
+}


### PR DESCRIPTION
* Enabling this feature creates a KMS key that can be used across all resources that support KMS encryption. Using a single KMS key can help reduce costs related to KMS. We can in future add a feature to use individual KMS keys for particular resources if needed.