### PR TITLE
Add 'Name' tag to VPC

### DIFF
--- a/vpc-infrastructure.tf
+++ b/vpc-infrastructure.tf
@@ -7,4 +7,8 @@ resource "aws_vpc" "infrastructure" {
   instance_tenancy                     = local.infrastructure_vpc_instance_tenancy
   enable_network_address_usage_metrics = local.infrastructure_vpc_enable_network_address_usage_metrics
   assign_generated_ipv6_cidr_block     = local.infrastructure_vpc_assign_generated_ipv6_cidr_block
+
+  tags = {
+    Name = "${local.resource_prefix}-infrastructure"
+  }
 }


### PR DESCRIPTION
* This resource doesn't have a name parameter, and requires the 'Name' tag to be set so that it appears in the console - which makes it more human readable within the console