### PR TITLE
Conditionally create Route53 Hosted Zone

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This project creates and manages resources within an AWS account for infrastruct
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 5.26.0 |
+| <a name="provider_aws.awsroute53root"></a> [aws.awsroute53root](#provider\_aws.awsroute53root) | 5.26.0 |
 
 ## Resources
 
@@ -51,6 +52,8 @@ This project creates and manages resources within an AWS account for infrastruct
 | [aws_network_acl_rule.ingress_public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_route.infrustructure_public_internet_gateway](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_route.private_nat_gateway](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
+| [aws_route53_record.infrastructure_ns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_zone.infrastructure](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
 | [aws_route_table.infrastructure_private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
 | [aws_route_table.infrastructure_public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
 | [aws_route_table_association.infrastructure_private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
@@ -65,12 +68,15 @@ This project creates and manages resources within an AWS account for infrastruct
 | [aws_subnet.infrastructure_public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_vpc.infrastructure](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_route53_zone.root](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_aws_profile_name_route53_root"></a> [aws\_profile\_name\_route53\_root](#input\_aws\_profile\_name\_route53\_root) | AWS Profile name which is configured for the account in which the root Route53 Hosted Zone exists. | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region in which to launch resources | `string` | n/a | yes |
+| <a name="input_enable_infrastructure_route53_hosted_zone"></a> [enable\_infrastructure\_route53\_hosted\_zone](#input\_enable\_infrastructure\_route53\_hosted\_zone) | Creates a Route53 hosted zone, where DNS records will be created for resources launched within this module. | `bool` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment name to be used as part of the resource prefix | `string` | n/a | yes |
 | <a name="input_infrastructure_kms_encryption"></a> [infrastructure\_kms\_encryption](#input\_infrastructure\_kms\_encryption) | Enable infrastructure KMS encryption. This will create a single KMS key to be used across all resources that support KMS encryption. | `bool` | n/a | yes |
 | <a name="input_infrastructure_logging_bucket_retention"></a> [infrastructure\_logging\_bucket\_retention](#input\_infrastructure\_logging\_bucket\_retention) | Retention in days for the infrasrtucture S3 logs. This is for the default S3 logs bucket, where all AWS service logs will be delivered | `number` | n/a | yes |
@@ -99,6 +105,7 @@ This project creates and manages resources within an AWS account for infrastruct
 | <a name="input_infrastructure_vpc_network_enable_private"></a> [infrastructure\_vpc\_network\_enable\_private](#input\_infrastructure\_vpc\_network\_enable\_private) | Enable private networking on Infrastructure VPC. This will create subnets with a route to a NAT Gateway (If Public networking has been enabled) | `bool` | n/a | yes |
 | <a name="input_infrastructure_vpc_network_enable_public"></a> [infrastructure\_vpc\_network\_enable\_public](#input\_infrastructure\_vpc\_network\_enable\_public) | Enable public networking on Infrastructure VPC. This will create subnets with a route to an Internet Gateway | `bool` | n/a | yes |
 | <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name to be used as a prefix for all resources | `string` | n/a | yes |
+| <a name="input_route53_root_hosted_zone_domain_name"></a> [route53\_root\_hosted\_zone\_domain\_name](#input\_route53\_root\_hosted\_zone\_domain\_name) | Route53 Hosted Zone in which to delegate Infrastructure Route53 Hosted Zones. | `string` | n/a | yes |
 
 ## Outputs
 

--- a/data.tf
+++ b/data.tf
@@ -1,1 +1,7 @@
 data "aws_caller_identity" "current" {}
+
+data "aws_route53_zone" "root" {
+  count = local.create_infrastructure_route53_delegations ? 1 : 0
+
+  name = local.route53_root_hosted_zone_domain_name
+}

--- a/locals.tf
+++ b/locals.tf
@@ -18,6 +18,12 @@ locals {
     local.infrastructure_vpc_flow_logs_s3_with_athena ? ["arn:aws:logs:${local.aws_region}:${local.aws_account_id}:*"] : [],
   )
 
+  route53_root_hosted_zone_domain_name      = var.route53_root_hosted_zone_domain_name
+  aws_profile_name_route53_root             = var.aws_profile_name_route53_root
+  enable_infrastructure_route53_hosted_zone = var.enable_infrastructure_route53_hosted_zone
+  create_infrastructure_route53_delegations = local.route53_root_hosted_zone_domain_name != "" && local.aws_profile_name_route53_root != "" && local.enable_infrastructure_route53_hosted_zone
+  infrastructure_route53_domain             = "${local.environment}.${var.infrastructure_name}.${local.route53_root_hosted_zone_domain_name}"
+
   infrastructure_vpc                                          = var.infrastructure_vpc
   infrastructure_vpc_cidr_block                               = var.infrastructure_vpc_cidr_block
   infrastructure_vpc_enable_dns_support                       = var.infrastructure_vpc_enable_dns_support

--- a/providers.tf
+++ b/providers.tf
@@ -5,3 +5,13 @@ provider "aws" {
     tags = local.default_tags
   }
 }
+
+provider "aws" {
+  region  = local.aws_region
+  alias   = "awsroute53root"
+  profile = local.aws_profile_name_route53_root != "" ? local.aws_profile_name_route53_root : null
+
+  default_tags {
+    tags = local.default_tags
+  }
+}

--- a/route53-infrastructure.tf
+++ b/route53-infrastructure.tf
@@ -1,0 +1,23 @@
+resource "aws_route53_zone" "infrastructure" {
+  count = local.enable_infrastructure_route53_hosted_zone ? 1 : 0
+
+  name = local.infrastructure_route53_domain
+}
+
+resource "aws_route53_record" "infrastructure_ns" {
+  count = local.create_infrastructure_route53_delegations ? 1 : 0
+
+  provider = aws.awsroute53root
+
+  name    = local.infrastructure_route53_domain
+  ttl     = 172800
+  type    = "NS"
+  zone_id = data.aws_route53_zone.root[0].zone_id
+
+  records = [
+    aws_route53_zone.infrastructure[0].name_servers[0],
+    aws_route53_zone.infrastructure[0].name_servers[1],
+    aws_route53_zone.infrastructure[0].name_servers[2],
+    aws_route53_zone.infrastructure[0].name_servers[3],
+  ]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -178,3 +178,18 @@ variable "infrastructure_vpc_network_acl_ingress_custom_rules_public" {
     icmp_code       = optional(number, null)
   }))
 }
+
+variable "route53_root_hosted_zone_domain_name" {
+  description = "Route53 Hosted Zone in which to delegate Infrastructure Route53 Hosted Zones."
+  type        = string
+}
+
+variable "aws_profile_name_route53_root" {
+  description = "AWS Profile name which is configured for the account in which the root Route53 Hosted Zone exists."
+  type        = string
+}
+
+variable "enable_infrastructure_route53_hosted_zone" {
+  description = "Creates a Route53 hosted zone, where DNS records will be created for resources launched within this module."
+  type        = bool
+}


### PR DESCRIPTION
* This allows creating Route53 Hosted Zones, with delegation (NS) records created in anoter (root) Route53 zone.
* To create the delegation records, an AWS profile name must be provided, and the current user must have access to read/write to that Route53 zone
* The Infrastructure Route53 zone will be used to hold DNS records for the resources launched.