### PR TITLE
Fix: Role name lengths

### DIFF
--- a/ecs-cluster-infrastructure-draining-lambda.tf
+++ b/ecs-cluster-infrastructure-draining-lambda.tf
@@ -9,7 +9,8 @@ resource "aws_cloudwatch_log_group" "ecs_cluster_infrastructure_draining_lambda_
 resource "aws_iam_role" "ecs_cluster_infrastructure_draining_lambda" {
   count = local.infrastructure_ecs_cluster_draining_lambda_enabled ? 1 : 0
 
-  name = "${local.resource_prefix}-ecs-cluster-infrastructure-draining-lambda"
+  name        = "${local.resource_prefix}-${substr(sha512("ecs-cluster-infrastructure-draining-lambda"), 0, 6)}"
+  description = "${local.resource_prefix}-ecs-cluster-infrastructure-draining-lambda"
   assume_role_policy = templatefile(
     "${path.root}/policies/assume-roles/service-principle-standard.json.tpl",
     { services = jsonencode(["lambda.amazonaws.com"]) }

--- a/ecs-cluster-infrastructure.tf
+++ b/ecs-cluster-infrastructure.tf
@@ -104,7 +104,8 @@ resource "aws_security_group_rule" "infrastructure_ecs_cluster_container_instanc
 resource "aws_iam_role" "infrastructure_ecs_cluster" {
   count = local.enable_infrastructure_ecs_cluster ? 1 : 0
 
-  name = "${local.resource_prefix}-infrastructure-ecs-cluster"
+  name        = "${local.resource_prefix}-${substr(sha512("infrastructure-ecs-cluster"), 0, 6)}"
+  description = "${local.resource_prefix}-infrastructure-ecs-cluster"
   assume_role_policy = templatefile(
     "${path.root}/policies/assume-roles/service-principle-standard.json.tpl",
     { services = jsonencode(["ecs.amazonaws.com", "ec2.amazonaws.com"]) }
@@ -265,7 +266,8 @@ resource "aws_sns_topic" "infrastructure_ecs_cluster_autoscaling_lifecycle_termi
 resource "aws_iam_role" "infrastructure_ecs_cluster_autoscaling_lifecycle_termination" {
   count = local.enable_infrastructure_ecs_cluster ? 1 : 0
 
-  name = "${local.resource_prefix}-ecs-termination-hook"
+  name        = "${local.resource_prefix}-${substr(sha512("ecs-termination-hook"), 0, 6)}"
+  description = "${local.resource_prefix}-ecs-termination-hook"
   assume_role_policy = templatefile(
     "${path.root}/policies/assume-roles/service-principle-standard.json.tpl",
     { services = jsonencode(["autoscaling.amazonaws.com"]) }

--- a/vpc-infrastructure-flow-logs-cloudwatch.tf
+++ b/vpc-infrastructure-flow-logs-cloudwatch.tf
@@ -10,7 +10,8 @@ resource "aws_cloudwatch_log_group" "infrastructure_vpc_flow_logs" {
 resource "aws_iam_role" "infrastructure_vpc_flow_logs" {
   count = local.infrastructure_vpc_flow_logs_cloudwatch_logs ? 1 : 0
 
-  name = "${local.resource_prefix}-infrastructure-vpc-flow-logs"
+  name        = "${local.resource_prefix}-${substr(sha512("infrastructure-vpc-flow-logs"), 0, 6)}"
+  description = "${local.resource_prefix}-infrastructure-vpc-flow-logs"
   assume_role_policy = templatefile("${path.root}/policies/assume-roles/service-principle-standard.json.tpl", {
     services = jsonencode(["vpc-flow-logs.amazonaws.com"])
   })


### PR DESCRIPTION
* A role name can only be 64 characters
* This fix uses a hash of the role suffix instead of the full name, and then adds the full name as a description.