### PR TITLE
Enable ECS Cluster autoscaling group metrics

### DIFF
--- a/ecs-cluster-infrastructure.tf
+++ b/ecs-cluster-infrastructure.tf
@@ -254,6 +254,30 @@ resource "aws_autoscaling_group" "infrastructure_ecs_cluster" {
   timeouts {
     delete = "15m"
   }
+
+  enabled_metrics = [
+    "GroupAndWarmPoolDesiredCapacity",
+    "GroupAndWarmPoolTotalCapacity",
+    "GroupDesiredCapacity",
+    "GroupInServiceCapacity",
+    "GroupInServiceInstances",
+    "GroupMaxSize",
+    "GroupMinSize",
+    "GroupPendingCapacity",
+    "GroupPendingInstances",
+    "GroupStandbyCapacity",
+    "GroupStandbyInstances",
+    "GroupTerminatingCapacity",
+    "GroupTerminatingInstances",
+    "GroupTotalCapacity",
+    "GroupTotalInstances",
+    "WarmPoolDesiredCapacity",
+    "WarmPoolMinSize",
+    "WarmPoolPendingCapacity",
+    "WarmPoolTerminatingCapacity",
+    "WarmPoolTotalCapacity",
+    "WarmPoolWarmedCapacity",
+  ]
 }
 
 resource "aws_sns_topic" "infrastructure_ecs_cluster_autoscaling_lifecycle_termination" {


### PR DESCRIPTION
* Adds the list of enabled metrics for the ECS Cluster's autoscaling group. These are the metrics that are automatically enabled when choosing to enable metrics within the AWS console, which is also the full list of metrics avaiable for the autoscaling group.