### PR TITLE
ECS Service Blue/Green deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This project creates and manages resources within an AWS account for infrastruct
 | <a name="requirement_archive"></a> [archive](#requirement\_archive) | >= 2.4.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.30.0 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | >= 2.3.2 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.2.2 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.6.0 |
 
 ## Providers
@@ -25,6 +26,7 @@ This project creates and manages resources within an AWS account for infrastruct
 | <a name="provider_aws.awsroute53root"></a> [aws.awsroute53root](#provider\_aws.awsroute53root) | 5.38.0 |
 | <a name="provider_aws.useast1"></a> [aws.useast1](#provider\_aws.useast1) | 5.38.0 |
 | <a name="provider_external"></a> [external](#provider\_external) | 2.3.3 |
+| <a name="provider_null"></a> [null](#provider\_null) | >= 3.2.2 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.6.0 |
 
 ## Resources
@@ -42,6 +44,8 @@ This project creates and manages resources within an AWS account for infrastruct
 | [aws_alb_listener_rule.infrastructure_ecs_cluster_service_host_header](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/alb_listener_rule) | resource |
 | [aws_alb_listener_rule.service_alb_host_rule_bypass_exclusions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/alb_listener_rule) | resource |
 | [aws_alb_target_group.infrastructure_ecs_cluster_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/alb_target_group) | resource |
+| [aws_alb_target_group.infrastructure_ecs_cluster_service_blue](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/alb_target_group) | resource |
+| [aws_alb_target_group.infrastructure_ecs_cluster_service_green](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/alb_target_group) | resource |
 | [aws_athena_workgroup.infrastructure_vpc_flow_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/athena_workgroup) | resource |
 | [aws_autoscaling_group.infrastructure_ecs_cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group) | resource |
 | [aws_autoscaling_lifecycle_hook.infrastructure_ecs_cluster_termination](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_lifecycle_hook) | resource |
@@ -56,6 +60,9 @@ This project creates and manages resources within an AWS account for infrastruct
 | [aws_cloudwatch_log_group.infrastructure_rds_exports](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.infrastructure_vpc_flow_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_codebuild_project.infrastructure_ecs_cluster_service_build](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codebuild_project) | resource |
+| [aws_codedeploy_app.infrastructure_ecs_cluster_service_blue_green](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codedeploy_app) | resource |
+| [aws_codedeploy_deployment_config.infrastructure_ecs_cluster_service_blue_green](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codedeploy_deployment_config) | resource |
+| [aws_codedeploy_deployment_group.infrastructure_ecs_cluster_service_blue_green](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codedeploy_deployment_group) | resource |
 | [aws_codepipeline.infrastructure_ecs_cluster_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codepipeline) | resource |
 | [aws_db_instance.infrastructure_rds](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance) | resource |
 | [aws_db_option_group.infrastructure_rds](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_option_group) | resource |
@@ -86,10 +93,14 @@ This project creates and manages resources within an AWS account for infrastruct
 | [aws_iam_policy.infrastructure_ecs_cluster_autoscaling_lifecycle_termination_sns_publish](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.infrastructure_ecs_cluster_ec2_ecs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.infrastructure_ecs_cluster_pass_role_ssm_dhmc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.infrastructure_ecs_cluster_service_blue_green_codedeploy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.infrastructure_ecs_cluster_service_blue_green_codedeploy_kms_encrypt](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.infrastructure_ecs_cluster_service_codebuild](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.infrastructure_ecs_cluster_service_codebuild_blue_green](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.infrastructure_ecs_cluster_service_codebuild_ecr_push](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.infrastructure_ecs_cluster_service_codebuild_kms_encrypt](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.infrastructure_ecs_cluster_service_codepipeline](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.infrastructure_ecs_cluster_service_codepipeline_codedeploy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.infrastructure_ecs_cluster_service_codepipeline_codestar_connection](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.infrastructure_ecs_cluster_service_codepipeline_kms_encrypt](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.infrastructure_ecs_cluster_service_task_execution_cloudwatch_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
@@ -101,6 +112,7 @@ This project creates and manages resources within an AWS account for infrastruct
 | [aws_iam_role.ecs_cluster_infrastructure_draining_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.infrastructure_ecs_cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.infrastructure_ecs_cluster_autoscaling_lifecycle_termination](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.infrastructure_ecs_cluster_service_blue_green_codedeploy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.infrastructure_ecs_cluster_service_codebuild](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.infrastructure_ecs_cluster_service_codepipeline](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.infrastructure_ecs_cluster_service_task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
@@ -116,10 +128,14 @@ This project creates and manages resources within an AWS account for infrastruct
 | [aws_iam_role_policy_attachment.infrastructure_ecs_cluster_autoscaling_lifecycle_termination_sns_publish](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.infrastructure_ecs_cluster_ec2_ecs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.infrastructure_ecs_cluster_pass_role_ssm_dhmc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.infrastructure_ecs_cluster_service_blue_green_codedeploy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.infrastructure_ecs_cluster_service_blue_green_codedeploy_kms_encrypt](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.infrastructure_ecs_cluster_service_codebuild](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.infrastructure_ecs_cluster_service_codebuild_blue_green](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.infrastructure_ecs_cluster_service_codebuild_ecr_push](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.infrastructure_ecs_cluster_service_codebuild_kms_encrypt](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.infrastructure_ecs_cluster_service_codepipeline](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.infrastructure_ecs_cluster_service_codepipeline_codedeploy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.infrastructure_ecs_cluster_service_codepipeline_codestar_connection](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.infrastructure_ecs_cluster_service_codepipeline_kms_encrypt](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.infrastructure_ecs_cluster_service_task_execution_cloudwatch_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
@@ -227,6 +243,7 @@ This project creates and manages resources within an AWS account for infrastruct
 | [aws_subnet.infrastructure_private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_subnet.infrastructure_public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_vpc.infrastructure](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) | resource |
+| [null_resource.infrastructure_ecs_cluster_service_blue_green_create_codedeploy_deployment](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [random_password.infrastructure_ecs_cluster_service_cloudfront_bypass_protection_secret](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [random_password.infrastructure_rds_root](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [archive_file.ecs_cluster_infrastructure_draining_lambda](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |

--- a/appspecs/ecs.json.tpl
+++ b/appspecs/ecs.json.tpl
@@ -1,0 +1,16 @@
+{
+  "Resources": [
+    {
+      "TargetService": {
+        "Type": "AWS::ECS::Service",
+        "Properties": {
+          "TaskDefinition": "${task_definition_arn}",
+          "LoadBalancerInfo": {
+            "ContainerName": "${container_name}",
+            "ContainerPort": ${container_port}
+          }
+        }
+      }
+    }
+  ]
+}

--- a/buildspecs/dalmatian-default.yml
+++ b/buildspecs/dalmatian-default.yml
@@ -29,12 +29,56 @@ phases:
       - IMAGE_TAG=commit-$CODEBUILD_RESOLVED_SOURCE_VERSION
       - docker push $REPOSITORY_URL:latest
       - docker push $REPOSITORY_URL:$IMAGE_TAG
+      - >-
+        if [ -n "$BLUE_GREEN" ];
+        then
+          echo "Writing appspec file..."
+          aws ecs describe-task-definition --task-definition "$TASK_DEFINITION_FAMILY" | jq > latest-task-definition.json;
+          cat latest-task-definition.json | jq -r --arg image "$REPOSITORY_URL:$IMAGE_TAG" '.taskDefinition.containerDefinitions | .[0].image = $image' > new-container-defs.json;
+          NEW_TASK_DEFINITION="$(aws ecs register-task-definition \
+            --family "$TASK_DEFINITION_FAMILY" \
+            --container-definitions file://new-container-defs.json \
+            --task-role-arn "$(cat latest-task-definition.json | jq -r '.taskDefinition.taskRoleArn')" \
+            --execution-role-arn "$(cat latest-task-definition.json | jq -r '.taskDefinition.executionRoleArn')" \
+            --network-mode "$(cat latest-task-definition.json | jq -r '.taskDefinition.networkMode')" \
+            --volumes "$(cat latest-task-definition.json | jq -r '.taskDefinition.volumes')" \
+            --placement-constraints "$(cat latest-task-definition.json | jq -r '.taskDefinition.placementConstraints')" \
+            --requires-compatibilities "$(cat latest-task-definition.json | jq -r '.taskDefinition.requiresCompatibilities')")";
+          NEW_TASK_DEFINITION_ARN=$(echo "$NEW_TASK_DEFINITION" | jq -r '.taskDefinition.taskDefinitionArn')
+          CONTAINER_PORT=$(echo "$NEW_TASK_DEFINITION" | jq -r '.taskDefinition.containerDefinitions[0].portMappings[0].containerPort')
+          APPSPEC=$(jq -rn \
+            --arg task_definition_arn "$NEW_TASK_DEFINITION_ARN" \
+            --arg container_name "$CONTAINER_NAME" \
+            --argjson container_port "$CONTAINER_PORT" \
+            '{
+              Resources: [
+                {
+                  TargetService: {
+                    Type: "AWS::ECS::Service",
+                    Properties: {
+                      TaskDefinition: $task_definition_arn,
+                      LoadBalancerInfo: {
+                        ContainerName: $container_name,
+                        ContainerPort: $container_port
+                      }
+                    }
+                  }
+                }
+              ]
+            }')
+            echo "$APPSPEC" > appspec.json
+        fi
+      - touch appspec.json
       - echo "Writing image definitions file..."
       - printf '[{"name":"%s","imageUri":"%s"}]' $CONTAINER_NAME $REPOSITORY_URL:$IMAGE_TAG > imagedefinitions.json
 artifacts:
   files:
     - imagedefinitions.json
+    - appspec.json
   secondary-artifacts:
     imagedefinitions:
       files:
         - imagedefinitions.json
+    appspec:
+      files:
+        - appspec.json

--- a/ecs-cluster-infrastructure-service-alb.tf
+++ b/ecs-cluster-infrastructure-service-alb.tf
@@ -159,7 +159,7 @@ resource "aws_alb_listener_rule" "infrastructure_ecs_cluster_service_host_header
 
   action {
     type             = "forward"
-    target_group_arn = each.value["deployment_type"] == "rolling" ? aws_alb_target_group.infrastructure_ecs_cluster_service[each.key].arn : null
+    target_group_arn = each.value["deployment_type"] == "rolling" ? aws_alb_target_group.infrastructure_ecs_cluster_service[each.key].arn : each.value["deployment_type"] == "blue-green" ? aws_alb_target_group.infrastructure_ecs_cluster_service_blue[each.key].arn : null
   }
 
   dynamic "condition" {
@@ -199,7 +199,7 @@ resource "aws_alb_listener_rule" "service_alb_host_rule_bypass_exclusions" {
 
   action {
     type             = "forward"
-    target_group_arn = each.value["deployment_type"] == "rolling" ? aws_alb_target_group.infrastructure_ecs_cluster_service[each.key].arn : null
+    target_group_arn = each.value["deployment_type"] == "rolling" ? aws_alb_target_group.infrastructure_ecs_cluster_service[each.key].arn : each.value["deployment_type"] == "blue-green" ? aws_alb_target_group.infrastructure_ecs_cluster_service_blue[each.key].arn : null
   }
 
   condition {

--- a/ecs-cluster-infrastructure-service-codedeploy-blue-green.tf
+++ b/ecs-cluster-infrastructure-service-codedeploy-blue-green.tf
@@ -1,0 +1,174 @@
+resource "aws_codedeploy_app" "infrastructure_ecs_cluster_service_blue_green" {
+  for_each = {
+    for k, v in local.infrastructure_ecs_cluster_services : k => v if v["deployment_type"] == "blue-green"
+  }
+
+  compute_platform = "ECS"
+  name             = "${local.resource_prefix}-ecs-service-b-g-${each.key}"
+}
+
+resource "aws_codedeploy_deployment_config" "infrastructure_ecs_cluster_service_blue_green" {
+  for_each = {
+    for k, v in local.infrastructure_ecs_cluster_services : k => v if v["deployment_type"] == "blue-green"
+  }
+
+  deployment_config_name = "${local.resource_prefix}-ecs-service-b-g-${each.key}"
+  compute_platform       = "ECS"
+
+  traffic_routing_config {
+    type = "AllAtOnce"
+  }
+}
+
+resource "aws_iam_role" "infrastructure_ecs_cluster_service_blue_green_codedeploy" {
+  for_each = {
+    for k, v in local.infrastructure_ecs_cluster_services : k => v if v["deployment_type"] == "blue-green"
+  }
+
+  name        = "${local.resource_prefix}-${substr(sha512("ecs-cluster-service-blue-green-codedeploy-${each.key}"), 0, 6)}"
+  description = "${local.resource_prefix}-ecs-cluster-service-blue-green-codedeploy-${each.key}"
+  assume_role_policy = templatefile(
+    "${path.root}/policies/assume-roles/service-principle-standard.json.tpl",
+    { services = jsonencode(["codedeploy.amazonaws.com"]) }
+  )
+}
+
+resource "aws_iam_policy" "infrastructure_ecs_cluster_service_blue_green_codedeploy" {
+  for_each = {
+    for k, v in local.infrastructure_ecs_cluster_services : k => v if v["deployment_type"] == "blue-green"
+  }
+
+  name        = "${local.resource_prefix}-${substr(sha512("ecs-cluster-service-blue-green-codedeploy-${each.key}"), 0, 6)}"
+  description = "${local.resource_prefix}-ecs-cluster-service-blue-green-codedeploy-${each.key}"
+  policy      = templatefile("${path.root}/policies/ecs-codedeploy.json.tpl", {})
+}
+
+resource "aws_iam_role_policy_attachment" "infrastructure_ecs_cluster_service_blue_green_codedeploy" {
+  for_each = {
+    for k, v in local.infrastructure_ecs_cluster_services : k => v if v["deployment_type"] == "blue-green"
+  }
+
+  role       = aws_iam_role.infrastructure_ecs_cluster_service_blue_green_codedeploy[each.key].name
+  policy_arn = aws_iam_policy.infrastructure_ecs_cluster_service_blue_green_codedeploy[each.key].arn
+}
+
+resource "aws_iam_policy" "infrastructure_ecs_cluster_service_blue_green_codedeploy_kms_encrypt" {
+  for_each = local.infrastructure_kms_encryption ? {
+    for k, v in local.infrastructure_ecs_cluster_services : k => v if v["deployment_type"] == "blue-green"
+  } : {}
+
+  name        = "${local.resource_prefix}-${substr(sha512("ecs-cluster-service-blue-green-codedeploy-${each.key}-kms-encrypt"), 0, 6)}"
+  description = "${local.resource_prefix}-ecs-cluster-service-blue-green-codedeploy-${each.key}-kms-encrypt"
+  policy = templatefile(
+    "${path.root}/policies/kms-encrypt.json.tpl",
+    { kms_key_arn = aws_kms_key.infrastructure[0].arn }
+  )
+}
+
+resource "aws_iam_role_policy_attachment" "infrastructure_ecs_cluster_service_blue_green_codedeploy_kms_encrypt" {
+  for_each = local.infrastructure_kms_encryption ? {
+    for k, v in local.infrastructure_ecs_cluster_services : k => v if v["deployment_type"] == "blue-green"
+  } : {}
+
+  role       = aws_iam_role.infrastructure_ecs_cluster_service_blue_green_codedeploy[each.key].name
+  policy_arn = aws_iam_policy.infrastructure_ecs_cluster_service_blue_green_codedeploy_kms_encrypt[each.key].arn
+}
+
+resource "aws_codedeploy_deployment_group" "infrastructure_ecs_cluster_service_blue_green" {
+  for_each = {
+    for k, v in local.infrastructure_ecs_cluster_services : k => v if v["deployment_type"] == "blue-green"
+  }
+
+  app_name               = aws_codedeploy_app.infrastructure_ecs_cluster_service_blue_green[each.key].name
+  deployment_config_name = aws_codedeploy_deployment_config.infrastructure_ecs_cluster_service_blue_green[each.key].deployment_config_name
+  deployment_group_name  = "${local.resource_prefix}-ecs-service-b-g-${each.key}"
+  service_role_arn       = aws_iam_role.infrastructure_ecs_cluster_service_blue_green_codedeploy[each.key].arn
+
+  auto_rollback_configuration {
+    enabled = true
+    events  = ["DEPLOYMENT_FAILURE"]
+  }
+
+  blue_green_deployment_config {
+    deployment_ready_option {
+      action_on_timeout = "CONTINUE_DEPLOYMENT"
+    }
+
+    terminate_blue_instances_on_deployment_success {
+      action                           = "TERMINATE"
+      termination_wait_time_in_minutes = 5
+    }
+  }
+
+  deployment_style {
+    deployment_option = "WITH_TRAFFIC_CONTROL"
+    deployment_type   = "BLUE_GREEN"
+  }
+
+  ecs_service {
+    cluster_name = aws_ecs_cluster.infrastructure[0].name
+    service_name = each.key
+  }
+
+  load_balancer_info {
+    target_group_pair_info {
+      prod_traffic_route {
+        listener_arns = [
+          local.enable_infrastructure_wildcard_certificate ? aws_alb_listener.infrastructure_ecs_cluster_service_https[0].arn : aws_alb_listener.infrastructure_ecs_cluster_service_http[0].arn
+        ]
+      }
+
+      target_group {
+        name = aws_alb_target_group.infrastructure_ecs_cluster_service_green[each.key].name
+      }
+
+      target_group {
+        name = aws_alb_target_group.infrastructure_ecs_cluster_service_blue[each.key].name
+      }
+    }
+  }
+}
+
+resource "null_resource" "infrastructure_ecs_cluster_service_blue_green_create_codedeploy_deployment" {
+  for_each = {
+    for k, v in local.infrastructure_ecs_cluster_services : k => v if v["deployment_type"] == "blue-green"
+  }
+
+  triggers = {
+    appspec_sha256 = sha256(templatefile(
+      "${path.root}/appspecs/ecs.json.tpl",
+      {
+        task_definition_arn = aws_ecs_task_definition.infrastructure_ecs_cluster_service[each.key].arn
+        container_port      = each.value["container_port"] != null ? each.value["container_port"] : 0
+        container_name      = each.key
+      }
+    ))
+  }
+
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+    command = <<EOF
+    ${path.root}/local-exec-scripts/create-codedeploy-deployment.sh \
+      -a "${aws_codedeploy_app.infrastructure_ecs_cluster_service_blue_green[each.key].name}" \
+      -g "${aws_codedeploy_deployment_group.infrastructure_ecs_cluster_service_blue_green[each.key].deployment_group_name}" \
+      -A "${replace(templatefile(
+    "${path.root}/appspecs/ecs.json.tpl",
+    {
+      task_definition_arn = aws_ecs_task_definition.infrastructure_ecs_cluster_service[each.key].arn
+      container_port      = each.value["container_port"] != null ? each.value["container_port"] : 0
+      container_name      = each.key
+    }), "\"", "\\\"")}" \
+      -S "${sha256(templatefile(
+    "${path.root}/appspecs/ecs.json.tpl",
+    {
+      task_definition_arn = aws_ecs_task_definition.infrastructure_ecs_cluster_service[each.key].arn
+      container_port      = each.value["container_port"] != null ? each.value["container_port"] : 0
+      container_name      = each.key
+}))}"
+    EOF
+}
+
+depends_on = [
+  aws_codepipeline.infrastructure_ecs_cluster_service,
+]
+}

--- a/ecs-cluster-infrastructure-service-target-group.tf
+++ b/ecs-cluster-infrastructure-service-target-group.tf
@@ -3,7 +3,61 @@ resource "aws_alb_target_group" "infrastructure_ecs_cluster_service" {
     for k, v in local.infrastructure_ecs_cluster_services : k => v if v["deployment_type"] == "rolling"
   }
 
-  name = "${local.resource_prefix}-${each.key}"
+  name = "${local.resource_prefix_hash}-${each.key}"
+
+  port        = "80"
+  protocol    = "HTTP"
+  vpc_id      = aws_vpc.infrastructure[0].id
+  target_type = "instance"
+
+  health_check {
+    enabled             = true
+    interval            = 30
+    path                = each.value["container_heath_check_path"]
+    port                = "traffic-port"
+    protocol            = "HTTP"
+    timeout             = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 5
+    matcher             = "200,301,302"
+  }
+
+  deregistration_delay = each.value["deregistration_delay"]
+}
+
+resource "aws_alb_target_group" "infrastructure_ecs_cluster_service_blue" {
+  for_each = {
+    for k, v in local.infrastructure_ecs_cluster_services : k => v if v["deployment_type"] == "blue-green"
+  }
+
+  name = "${local.resource_prefix_hash}-b-${each.key}"
+
+  port        = "80"
+  protocol    = "HTTP"
+  vpc_id      = aws_vpc.infrastructure[0].id
+  target_type = "instance"
+
+  health_check {
+    enabled             = true
+    interval            = 30
+    path                = each.value["container_heath_check_path"]
+    port                = "traffic-port"
+    protocol            = "HTTP"
+    timeout             = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 5
+    matcher             = "200,301,302"
+  }
+
+  deregistration_delay = each.value["deregistration_delay"]
+}
+
+resource "aws_alb_target_group" "infrastructure_ecs_cluster_service_green" {
+  for_each = {
+    for k, v in local.infrastructure_ecs_cluster_services : k => v if v["deployment_type"] == "blue-green"
+  }
+
+  name = "${local.resource_prefix_hash}-g-${each.key}"
 
   port        = "80"
   protocol    = "HTTP"

--- a/local-exec-scripts/create-codedeploy-deployment.sh
+++ b/local-exec-scripts/create-codedeploy-deployment.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+
+# exit on failures
+set -e
+set -o pipefail
+
+usage() {
+  echo "Usage: $(basename "$0") [OPTIONS]" 1>&2
+  echo "  -h   - help"
+  echo "  -a   - CodeDeploy application name"
+  echo "  -g   - CodeDeploy group name"
+  echo "  -A   - Appspec content"
+  echo "  -S   - Appspec sha256"
+  exit 1
+}
+
+while getopts "a:g:A:S:h" opt; do
+  case $opt in
+    a)
+      APPLICATION_NAME=$OPTARG
+      ;;
+    g)
+      GROUP_NAME=$OPTARG
+      ;;
+    A)
+      APPSPEC_CONTENT=$OPTARG
+      ;;
+    S)
+      APPSPEC_SHA=$OPTARG
+      ;;
+    h)
+      usage
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+if [[
+  -z "$APPLICATION_NAME" ||
+  -z "$GROUP_NAME" ||
+  -z "$APPSPEC_CONTENT" ||
+  -z "$APPSPEC_SHA"
+]]
+then
+  usage
+fi
+
+DEPLOYMENT_REVISION=$(
+  jq -rn \
+  --arg appspec_content "$APPSPEC_CONTENT" \
+  --arg appspec_sha "$APPSPEC_SHA" \
+  '{
+    revisionType: "AppSpecContent",
+    appSpecContent: {
+      content: $appspec_content,
+      sha256: $appspec_sha
+    }
+  }'
+)
+
+echo "==> Creating Deployment for '$APPLICATION_NAME' ..."
+DEPLOYMENT_ID=$(
+  aws deploy create-deployment \
+  --application-name "$APPLICATION_NAME" \
+  --deployment-group-name "$GROUP_NAME" \
+  --revision "$DEPLOYMENT_REVISION" \
+  --output text \
+  --query '[deploymentId]'
+)
+
+echo "==> Checking deployment '$DEPLOYMENT_ID' ..."
+DEPLOYMENT_STATUS=$(
+  aws deploy get-deployment \
+  --deployment-id $DEPLOYMENT_ID \
+  --output text \
+  --query '[deploymentInfo.status]'
+)
+
+while [[
+  $DEPLOYMENT_STATUS == "Created" ||
+  $DEPLOYMENT_STATUS == "InProgress" ||
+  $DEPLOYMENT_STATUS == "Pending" ||
+  $DEPLOYMENT_STATUS == "Queued" ||
+  $DEPLOYMENT_STATUS == "Ready"
+]]
+do
+  echo "==> Deployment status: $DEPLOYMENT_STATUS..."
+  DEPLOYMENT_STATUS=$(
+    aws deploy get-deployment \
+    --deployment-id $DEPLOYMENT_ID \
+    --output text \
+    --query '[deploymentInfo.status]'
+  )
+  sleep 10
+done
+
+if [[ $DEPLOYMENT_STATUS == "Succeeded" ]]
+then
+  echo "==> Deployment Succeeded!"
+else
+  echo "==> Deployment Failed! (Status: $DEPLOYMENT_STATUS)"
+  exit 1
+fi
+
+# Original script sourced from https://dev.to/aws-builders/ecs-bluegreen-deployment-with-codedeploy-and-terraform-3gf1
+# Thanks :)

--- a/policies/codebuild-default.json.tpl
+++ b/policies/codebuild-default.json.tpl
@@ -5,9 +5,11 @@
       "Effect": "Allow",
       "Action": [
         "s3:GetBucketVersioning",
+        "s3:GetBucketLocation",
         "s3:GetObject",
         "s3:GetObjectVersion",
         "s3:PutObject",
+        "s3:GetBucketAcl",
         "s3:List*"
       ],
       "Resource": [

--- a/policies/codebuild-ecs-blue-green.json.tpl
+++ b/policies/codebuild-ecs-blue-green.json.tpl
@@ -1,0 +1,27 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ecs:DescribeTaskDefinition",
+        "ecs:RegisterTaskDefinition"
+      ],
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Action": "iam:PassRole",
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "iam:PassedToService": "ecs-tasks.amazonaws.com"
+        }
+      }
+    }
+  ]
+}

--- a/policies/codepipeline-ecs-codedeploy.json.tpl
+++ b/policies/codepipeline-ecs-codedeploy.json.tpl
@@ -1,0 +1,18 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "codedeploy:CreateDeployment",
+        "codedeploy:GetApplicationRevision",
+        "codedeploy:GetDeployment",
+        "codedeploy:GetDeploymentConfig",
+        "codedeploy:RegisterApplicationRevision"
+      ],
+      "Resource": [
+        "*"
+      ]
+    }
+  ]
+}

--- a/policies/ecs-codedeploy.json.tpl
+++ b/policies/ecs-codedeploy.json.tpl
@@ -1,0 +1,39 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "ecs:DescribeServices",
+        "ecs:CreateTaskSet",
+        "ecs:UpdateServicePrimaryTaskSet",
+        "ecs:DeleteTaskSet",
+        "elasticloadbalancing:DescribeTargetGroups",
+        "elasticloadbalancing:DescribeListeners",
+        "elasticloadbalancing:ModifyListener",
+        "elasticloadbalancing:DescribeRules",
+        "elasticloadbalancing:ModifyRule",
+        "lambda:InvokeFunction",
+        "cloudwatch:DescribeAlarms",
+        "sns:Publish",
+        "s3:GetObject",
+        "s3:GetObjectVersion"
+      ],
+      "Resource": "*",
+      "Effect": "Allow"
+    },
+    {
+      "Action": [
+        "iam:PassRole"
+      ],
+      "Effect": "Allow",
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "iam:PassedToService": [
+            "ecs-tasks.amazonaws.com"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/versions.tf
+++ b/versions.tf
@@ -13,6 +13,10 @@ terraform {
       source  = "hashicorp/external"
       version = ">= 2.3.2"
     }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 3.2.2"
+    }
     random = {
       source  = "hashicorp/random"
       version = ">= 3.6.0"


### PR DESCRIPTION
* Allows setting the ECS deployment type to Blue/Green
* Creates a CodeDeploy App for the ECS service, and configures the CodeBuild project to create a new task defintion and appspec to deploy new revisions
* Runs a script to create a new deployment if the task defintion is updated in terraform
* If switching from "rolling" to "blue-green", the service must first be destroyed and recreated, due to the `ignore_changes` requirements for Blue/Green deployments (eg. service loadbalancer target groups)