### PR TITLE
Fix Global Accelerator name length

### DIFF
--- a/ecs-cluster-infrastructure-service-alb-global-accelerator.tf
+++ b/ecs-cluster-infrastructure-service-alb-global-accelerator.tf
@@ -1,7 +1,7 @@
 resource "aws_globalaccelerator_accelerator" "infrastructure_ecs_cluster_service_alb" {
   count = local.infrastructure_ecs_cluster_services_alb_enable_global_accelerator ? 1 : 0
 
-  name            = "${local.resource_prefix}-infrastructure-ecs-cluster-service-alb"
+  name            = "${local.resource_prefix_hash}-infrastructure-ecs-cluster-service-alb"
   ip_address_type = "DUAL_STACK"
   enabled         = true
 }


### PR DESCRIPTION
* Has a max length of 64 chars, so need to use the resource prefix hash instead