### PR TITLE
Fix container port 0

### DIFF
--- a/ecs-cluster-infrastructure-service-alb.tf
+++ b/ecs-cluster-infrastructure-service-alb.tf
@@ -176,7 +176,7 @@ resource "aws_alb_listener" "infrastructure_ecs_cluster_service_https_custom" {
 
 resource "aws_alb_listener_rule" "infrastructure_ecs_cluster_service_host_header" {
   for_each = {
-    for k, service in local.infrastructure_ecs_cluster_services : k => service if service["domain_names"] == null
+    for k, service in local.infrastructure_ecs_cluster_services : k => service if service["domain_names"] == null && service["container_port"] != 0
   }
 
   listener_arn = local.enable_infrastructure_wildcard_certificate ? aws_alb_listener.infrastructure_ecs_cluster_service_https[0].arn : aws_alb_listener.infrastructure_ecs_cluster_service_http[0].arn
@@ -212,7 +212,7 @@ resource "aws_alb_listener_rule" "infrastructure_ecs_cluster_service_host_header
 
 resource "aws_alb_listener_rule" "infrastructure_ecs_cluster_service_host_header_custom" {
   for_each = {
-    for k, service in local.infrastructure_ecs_cluster_services : k => service if service["domain_names"] != null
+    for k, service in local.infrastructure_ecs_cluster_services : k => service if service["domain_names"] != null && service["container_port"] != 0
   }
 
   listener_arn = each.value["alb_tls_certificate_arn"] != null ? aws_alb_listener.infrastructure_ecs_cluster_service_https_custom[each.key].arn : aws_alb_listener.infrastructure_ecs_cluster_service_http[0].arn
@@ -251,7 +251,8 @@ resource "aws_alb_listener_rule" "service_alb_host_rule_bypass_exclusions" {
     for k, v in local.infrastructure_ecs_cluster_services : k => v if(
       v["enable_cloudfront"] == true &&
       v["cloudfront_bypass_protection_enabled"] == true &&
-      v["cloudfront_bypass_protection_excluded_domains"] != null
+      v["cloudfront_bypass_protection_excluded_domains"] != null &&
+      v["container_port"] != 0
     )
   }
 

--- a/ecs-cluster-infrastructure-service-codedeploy-blue-green.tf
+++ b/ecs-cluster-infrastructure-service-codedeploy-blue-green.tf
@@ -110,20 +110,23 @@ resource "aws_codedeploy_deployment_group" "infrastructure_ecs_cluster_service_b
     service_name = each.key
   }
 
-  load_balancer_info {
-    target_group_pair_info {
-      prod_traffic_route {
-        listener_arns = [
-          local.enable_infrastructure_wildcard_certificate ? aws_alb_listener.infrastructure_ecs_cluster_service_https[0].arn : aws_alb_listener.infrastructure_ecs_cluster_service_http[0].arn
-        ]
-      }
+  dynamic "load_balancer_info" {
+    for_each = each.value["container_port"] != 0 ? [1] : []
+    content {
+      target_group_pair_info {
+        prod_traffic_route {
+          listener_arns = [
+            local.enable_infrastructure_wildcard_certificate ? aws_alb_listener.infrastructure_ecs_cluster_service_https[0].arn : aws_alb_listener.infrastructure_ecs_cluster_service_http[0].arn
+          ]
+        }
 
-      target_group {
-        name = aws_alb_target_group.infrastructure_ecs_cluster_service_green[each.key].name
-      }
+        target_group {
+          name = aws_alb_target_group.infrastructure_ecs_cluster_service_green[each.key].name
+        }
 
-      target_group {
-        name = aws_alb_target_group.infrastructure_ecs_cluster_service_blue[each.key].name
+        target_group {
+          name = aws_alb_target_group.infrastructure_ecs_cluster_service_blue[each.key].name
+        }
       }
     }
   }

--- a/ecs-cluster-infrastructure-service-target-group.tf
+++ b/ecs-cluster-infrastructure-service-target-group.tf
@@ -1,6 +1,6 @@
 resource "aws_alb_target_group" "infrastructure_ecs_cluster_service" {
   for_each = {
-    for k, v in local.infrastructure_ecs_cluster_services : k => v if v["deployment_type"] == "rolling"
+    for k, v in local.infrastructure_ecs_cluster_services : k => v if v["deployment_type"] == "rolling" && v["container_port"] != 0
   }
 
   name = "${local.resource_prefix_hash}-${each.key}"
@@ -27,7 +27,7 @@ resource "aws_alb_target_group" "infrastructure_ecs_cluster_service" {
 
 resource "aws_alb_target_group" "infrastructure_ecs_cluster_service_blue" {
   for_each = {
-    for k, v in local.infrastructure_ecs_cluster_services : k => v if v["deployment_type"] == "blue-green"
+    for k, v in local.infrastructure_ecs_cluster_services : k => v if v["deployment_type"] == "blue-green" && v["container_port"] != 0
   }
 
   name = "${local.resource_prefix_hash}-b-${each.key}"
@@ -54,7 +54,7 @@ resource "aws_alb_target_group" "infrastructure_ecs_cluster_service_blue" {
 
 resource "aws_alb_target_group" "infrastructure_ecs_cluster_service_green" {
   for_each = {
-    for k, v in local.infrastructure_ecs_cluster_services : k => v if v["deployment_type"] == "blue-green"
+    for k, v in local.infrastructure_ecs_cluster_services : k => v if v["deployment_type"] == "blue-green" && v["container_port"] != 0
   }
 
   name = "${local.resource_prefix_hash}-g-${each.key}"

--- a/ecs-cluster-infrastructure-service.tf
+++ b/ecs-cluster-infrastructure-service.tf
@@ -183,7 +183,7 @@ resource "aws_ecs_service" "infrastructure_ecs_cluster_service" {
   }
 
   dynamic "load_balancer" {
-    for_each = each.value["deployment_type"] == "rolling" || each.value["deployment_type"] == "blue-green" ? [1] : []
+    for_each = (each.value["deployment_type"] == "rolling" || each.value["deployment_type"] == "blue-green") && each.value["container_port"] != 0 ? [1] : []
 
     content {
       target_group_arn = each.value["deployment_type"] == "rolling" ? aws_alb_target_group.infrastructure_ecs_cluster_service[each.key].arn : each.value["deployment_type"] == "blue-green" ? aws_alb_target_group.infrastructure_ecs_cluster_service_blue[each.key].arn : null

--- a/route53-infrastructure.tf
+++ b/route53-infrastructure.tf
@@ -68,7 +68,9 @@ resource "aws_route53_record" "service_loadbalancer_record_alb_global_accelerato
 }
 
 resource "aws_route53_record" "service_record" {
-  for_each = local.enable_infrastructure_route53_hosted_zone ? local.infrastructure_ecs_cluster_services : {}
+  for_each = local.enable_infrastructure_route53_hosted_zone ? {
+    for k, v in local.infrastructure_ecs_cluster_services : k => v if v["container_port"] != 0
+  } : {}
 
   zone_id = aws_route53_zone.infrastructure[0].zone_id
   name    = "${each.key}.${local.infrastructure_route53_domain}."


### PR DESCRIPTION
* A container that doesn't require access (eg. worker containers), the container port is set to 0. These containers don't require target groups, or load balancer configuration in the code deploy app.