### PR TITLE
Fix ALB certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ This project creates and manages resources within an AWS account for infrastruct
 | [aws_alb_listener.infrastructure_ecs_cluster_service_http](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/alb_listener) | resource |
 | [aws_alb_listener.infrastructure_ecs_cluster_service_http_https_redirect](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/alb_listener) | resource |
 | [aws_alb_listener.infrastructure_ecs_cluster_service_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/alb_listener) | resource |
-| [aws_alb_listener.infrastructure_ecs_cluster_service_https_custom](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/alb_listener) | resource |
 | [aws_alb_listener_rule.infrastructure_ecs_cluster_service_host_header](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/alb_listener_rule) | resource |
 | [aws_alb_listener_rule.infrastructure_ecs_cluster_service_host_header_custom](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/alb_listener_rule) | resource |
 | [aws_alb_listener_rule.service_alb_host_rule_bypass_exclusions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/alb_listener_rule) | resource |
@@ -179,6 +178,7 @@ This project creates and manages resources within an AWS account for infrastruct
 | [aws_lambda_function.ecs_cluster_infrastructure_draining](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
 | [aws_lambda_permission.ecs_cluster_infrastructure_draining_allow_sns_execution](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_launch_template.infrastructure_ecs_cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
+| [aws_lb_listener_certificate.service_shared_alb_certificate](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener_certificate) | resource |
 | [aws_nat_gateway.infrastructure](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/nat_gateway) | resource |
 | [aws_network_acl.infrastructure_private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl) | resource |
 | [aws_network_acl.infrastructure_public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl) | resource |

--- a/ecs-cluster-infrastructure-service-alb.tf
+++ b/ecs-cluster-infrastructure-service-alb.tf
@@ -152,28 +152,6 @@ resource "aws_alb_listener" "infrastructure_ecs_cluster_service_https" {
   }
 }
 
-resource "aws_alb_listener" "infrastructure_ecs_cluster_service_https_custom" {
-  for_each = {
-    for k, service in local.infrastructure_ecs_cluster_services : k => service if service["alb_tls_certificate_arn"] != null
-  }
-
-  load_balancer_arn = aws_alb.infrastructure_ecs_cluster_service[0].arn
-  port              = "443"
-  protocol          = "HTTPS"
-  certificate_arn   = each.value["alb_tls_certificate_arn"]
-  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
-
-  default_action {
-    type = "fixed-response"
-
-    fixed_response {
-      content_type = "text/plain"
-      message_body = "Misdirected Request"
-      status_code  = "421"
-    }
-  }
-}
-
 resource "aws_alb_listener_rule" "infrastructure_ecs_cluster_service_host_header" {
   for_each = {
     for k, service in local.infrastructure_ecs_cluster_services : k => service if service["domain_names"] == null && service["container_port"] != 0
@@ -215,7 +193,7 @@ resource "aws_alb_listener_rule" "infrastructure_ecs_cluster_service_host_header
     for k, service in local.infrastructure_ecs_cluster_services : k => service if service["domain_names"] != null && service["container_port"] != 0
   }
 
-  listener_arn = each.value["alb_tls_certificate_arn"] != null ? aws_alb_listener.infrastructure_ecs_cluster_service_https_custom[each.key].arn : aws_alb_listener.infrastructure_ecs_cluster_service_http[0].arn
+  listener_arn = each.value["alb_tls_certificate_arn"] != null ? aws_alb_listener.infrastructure_ecs_cluster_service_https[0].arn : aws_alb_listener.infrastructure_ecs_cluster_service_http[0].arn
 
   action {
     type             = "forward"
@@ -246,6 +224,15 @@ resource "aws_alb_listener_rule" "infrastructure_ecs_cluster_service_host_header
   }
 }
 
+resource "aws_lb_listener_certificate" "service_shared_alb_certificate" {
+  for_each = {
+    for k, service in local.infrastructure_ecs_cluster_services : k => service if service["domain_names"] != null && service["container_port"] != 0 && service["alb_tls_certificate_arn"] != null
+  }
+
+  listener_arn    = aws_alb_listener.infrastructure_ecs_cluster_service_https[0].arn
+  certificate_arn = each.value["alb_tls_certificate_arn"]
+}
+
 resource "aws_alb_listener_rule" "service_alb_host_rule_bypass_exclusions" {
   for_each = {
     for k, v in local.infrastructure_ecs_cluster_services : k => v if(
@@ -256,7 +243,7 @@ resource "aws_alb_listener_rule" "service_alb_host_rule_bypass_exclusions" {
     )
   }
 
-  listener_arn = local.enable_infrastructure_wildcard_certificate ? aws_alb_listener.infrastructure_ecs_cluster_service_https[0].arn : each.value["alb_tls_certificate_arn"] != null ? aws_alb_listener.infrastructure_ecs_cluster_service_https_custom[each.key].arn : aws_alb_listener.infrastructure_ecs_cluster_service_http[0].arn
+  listener_arn = local.enable_infrastructure_wildcard_certificate || each.value["alb_tls_certificate_arn"] != null ? aws_alb_listener.infrastructure_ecs_cluster_service_https[0].arn : aws_alb_listener.infrastructure_ecs_cluster_service_http[0].arn
 
   action {
     type             = "forward"


### PR DESCRIPTION
* A listener rule is needed, rather than a listener per service, and the certificate subsequently associated with the listener.