### PR TITLE
Ensure the ecs service has started

### DIFF
--- a/ec2-userdata/ecs-instance.tpl
+++ b/ec2-userdata/ecs-instance.tpl
@@ -39,3 +39,6 @@ cd /mnt/efs
 mkdir -p ${efs_dirs}
 cd ..
 %{~ endif}%{endif}
+
+# Ensure the ecs service has started
+sudo systemctl start ecs


### PR DESCRIPTION
* The ecs service sometimes fails to start, if docker fails to start on first try. This adds `systemctl start ecs` to the end of ec2 userdata, to force start it.