### PR TITLE
Upgrade to Amazon Linux 2023

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -19,7 +19,7 @@ data "aws_ami" "ecs_cluster_ami" {
   filter {
     name = "name"
     values = [
-      "amzn2-ami-ecs-hvm-${local.infrastructure_ecs_cluster_ami_version}"
+      "al2023-ami-ecs-hvm-${local.infrastructure_ecs_cluster_ami_version}"
     ]
   }
 


### PR DESCRIPTION
> Beginning with the June 12, 2024 releases of the Amazon ECS-optimized AMIs based on Amazon Linux 2, the default behavior will no longer include updating packages at launch. Instead, we recommend that you update to a new Amazon ECS-optimized AMI as releases are made available. The Amazon ECS-optimized AMIs are released when there are available security updates or base AMI changes. This will ensure you are receiving the latest package versions and security updates, and that the package versions are immutable through instance launches. For more information on retrieving the latest Amazon ECS-optimized AMI, see Retrieving Amazon ECS-optimized Linux AMI metadata.

* This changes the AMI from Amazon Linux 2 to Amazon Linux 2023