### PR TITLE
Use `--no-block` with systemctl in user data

### DIFF
--- a/ec2-userdata/ecs-instance.tpl
+++ b/ec2-userdata/ecs-instance.tpl
@@ -41,4 +41,4 @@ cd ..
 %{~ endif}%{endif}
 
 # Ensure the ecs service has started
-sudo systemctl start ecs
+sudo systemctl start --no-block ecs


### PR DESCRIPTION
> Do not synchronously wait for the requested operation to finish. If
> this is not specified, the job will be verified, enqueued and
> systemctl will wait until it is completed. By passing this
> argument, it is only verified and enqueued.