### PR TITLE
Fix: RDS identifier must start with a letter

### DIFF
--- a/rds-infrastructure-instance.tf
+++ b/rds-infrastructure-instance.tf
@@ -41,7 +41,7 @@ resource "aws_db_instance" "infrastructure_rds" {
     for k, v in local.infrastructure_rds : k => v if v["type"] == "instance"
   } : {}
 
-  identifier                  = "${local.resource_prefix_hash}-${each.key}"
+  identifier                  = "${regex("^[0-9]", substr(local.resource_prefix_hash, 0, 1)) != null ? "h" : ""}${local.resource_prefix_hash}-${each.key}"
   engine                      = local.rds_engines[each.value["type"]][each.value["engine"]]
   engine_version              = each.value["engine_version"]
   allow_major_version_upgrade = false


### PR DESCRIPTION
* If the resource prefix hash begins with a number, it fails to create the RDS, because the identifier must begin with a letter
* This change checks the first character of the hash, and if it is a number, it adds the letter 'h' to the beginning - For the RDS identifier only