### PR TITLE
Replace null_resource with terraform_data

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ This project creates and manages resources within an AWS account for infrastruct
 | <a name="provider_aws.awsroute53root"></a> [aws.awsroute53root](#provider\_aws.awsroute53root) | 5.58.0 |
 | <a name="provider_aws.useast1"></a> [aws.useast1](#provider\_aws.useast1) | 5.58.0 |
 | <a name="provider_external"></a> [external](#provider\_external) | 2.3.3 |
-| <a name="provider_null"></a> [null](#provider\_null) | >= 3.2.2 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.6.0 |
+| <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Resources
 
@@ -344,9 +344,9 @@ This project creates and manages resources within an AWS account for infrastruct
 | [aws_wafv2_ip_set.infrastructure_ecs_cluster_ipv6_allow_list](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_ip_set) | resource |
 | [aws_wafv2_ip_set.infrastructure_ecs_cluster_ipv6_deny_list](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_ip_set) | resource |
 | [aws_wafv2_web_acl.infrastructure_ecs_cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl) | resource |
-| [null_resource.infrastructure_ecs_cluster_service_blue_green_create_codedeploy_deployment](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [random_password.infrastructure_ecs_cluster_service_cloudfront_bypass_protection_secret](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [random_password.infrastructure_rds_root](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
+| [terraform_data.infrastructure_ecs_cluster_service_blue_green_create_codedeploy_deployment](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [archive_file.ecs_cluster_infrastructure_draining_lambda](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [archive_file.ecs_cluster_infrastructure_ecs_asg_diff_metric_lambda](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [archive_file.ecs_cluster_infrastructure_pending_task_metric_lambda](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |

--- a/ecs-cluster-infrastructure-service-codedeploy-blue-green.tf
+++ b/ecs-cluster-infrastructure-service-codedeploy-blue-green.tf
@@ -132,21 +132,21 @@ resource "aws_codedeploy_deployment_group" "infrastructure_ecs_cluster_service_b
   }
 }
 
-resource "null_resource" "infrastructure_ecs_cluster_service_blue_green_create_codedeploy_deployment" {
+resource "terraform_data" "infrastructure_ecs_cluster_service_blue_green_create_codedeploy_deployment" {
   for_each = {
     for k, v in local.infrastructure_ecs_cluster_services : k => v if v["deployment_type"] == "blue-green"
   }
 
-  triggers = {
-    appspec_sha256 = sha256(templatefile(
+  triggers_replace = [
+    sha256(templatefile(
       "${path.root}/appspecs/ecs.json.tpl",
       {
         task_definition_arn = aws_ecs_task_definition.infrastructure_ecs_cluster_service[each.key].arn
         container_port      = each.value["container_port"] != null ? each.value["container_port"] : 0
         container_name      = each.key
       }
-    ))
-  }
+    )),
+  ]
 
   provisioner "local-exec" {
     interpreter = ["/bin/bash", "-c"]


### PR DESCRIPTION
> The null_resource resource implements the standard resource lifecycle but takes no further action. On Terraform 1.4 and later, use the terraform_data resource type instead.