### PR TITLE
Create empty service env file

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ This project creates and manages resources within an AWS account for infrastruct
 | [random_password.infrastructure_ecs_cluster_service_cloudfront_bypass_protection_secret](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [random_password.infrastructure_rds_root](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [terraform_data.infrastructure_ecs_cluster_service_blue_green_create_codedeploy_deployment](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
+| [terraform_data.infrastructure_ecs_cluster_service_env_file](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [archive_file.ecs_cluster_infrastructure_draining_lambda](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [archive_file.ecs_cluster_infrastructure_ecs_asg_diff_metric_lambda](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [archive_file.ecs_cluster_infrastructure_pending_task_metric_lambda](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |

--- a/ecs-cluster-infrastructure-service-codedeploy-blue-green.tf
+++ b/ecs-cluster-infrastructure-service-codedeploy-blue-green.tf
@@ -173,5 +173,6 @@ resource "terraform_data" "infrastructure_ecs_cluster_service_blue_green_create_
 
 depends_on = [
   aws_codepipeline.infrastructure_ecs_cluster_service,
+  terraform_data.infrastructure_ecs_cluster_service_env_file,
 ]
 }

--- a/local-exec-scripts/create-empty-s3-object.sh
+++ b/local-exec-scripts/create-empty-s3-object.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# exit on failures
+set -e
+set -o pipefail
+
+usage() {
+  echo "Usage: $(basename "$0") [OPTIONS]" 1>&2
+  echo "  -h   - help"
+  echo "  -b   - Bucket"
+  echo "  -k   - Key"
+  exit 1
+}
+
+while getopts "b:k:h" opt; do
+  case $opt in
+    b)
+      BUCKET=$OPTARG
+      ;;
+    k)
+      KEY=$OPTARG
+      ;;
+    h)
+      usage
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+if [[
+  -z "$BUCKET" ||
+  -z "$KEY"
+]]
+then
+  usage
+fi
+
+if ! aws s3api head-object --bucket "$BUCKET" --key "$KEY" 2>/dev/null
+then
+    # If the file does not exist, create an empty file
+    touch /tmp/empty_file.txt
+    aws s3api put-object --bucket "$BUCKET" --key "$KEY" --body /tmp/empty_file.txt
+    rm /tmp/empty_file.txt
+    echo "==> Empty file created in S3 bucket"
+else
+    echo "==> File already exists in S3 bucket, skipping creation"
+fi


### PR DESCRIPTION
* When a new service is deployed, if the .env file doesn't exist in the environment files S3 bucket, the initial deployment will fail and terraform stops
* This adds a script to create an empty .env file for the service, only if the file doesn't exist (It won't overwrite existing files). The script is then ran when the bucklet or service name changes