### PR TITLE
Allow environment variables in app container definition

### DIFF
--- a/container-definitions/app.json.tpl
+++ b/container-definitions/app.json.tpl
@@ -29,6 +29,9 @@
       }
     ],
     %{ endif }
+    %{ if environment != "[]" }
+    "environment": "${environment},
+    %{ endif }
     %{ if environment_file_s3 != "" }
     "environmentFiles": [
       {

--- a/ecs-cluster-infrastructure-service-scheduled-task.tf
+++ b/ecs-cluster-infrastructure-service-scheduled-task.tf
@@ -21,6 +21,7 @@ resource "aws_ecs_task_definition" "infrastructure_ecs_cluster_service_scheduled
       image               = aws_ecr_repository.infrastructure_ecs_cluster_service[each.value["container_name"]].repository_url
       entrypoint          = each.value["entrypoint"] != null ? jsonencode(each.value["entrypoint"]) : "[]"
       environment_file_s3 = "${aws_s3_bucket.infrastructure_ecs_cluster_service_environment_files[0].arn}/${each.value["container_name"]}.env"
+      environment         = jsonencode([])
       container_port      = 0
       extra_hosts = each.value["extra_hosts"] != null ? jsonencode([
         for extra_host in each.value["extra_hosts"] : {

--- a/ecs-cluster-infrastructure-service.tf
+++ b/ecs-cluster-infrastructure-service.tf
@@ -223,6 +223,7 @@ resource "aws_ecs_task_definition" "infrastructure_ecs_cluster_service" {
       image               = aws_ecr_repository.infrastructure_ecs_cluster_service[each.key].repository_url
       entrypoint          = each.value["container_entrypoint"] != null ? jsonencode(each.value["container_entrypoint"]) : "[]"
       environment_file_s3 = "${aws_s3_bucket.infrastructure_ecs_cluster_service_environment_files[0].arn}/${each.key}.env"
+      environment         = jsonencode([])
       container_port      = each.value["container_port"] != null ? each.value["container_port"] : 0
       extra_hosts = each.value["container_extra_hosts"] != null ? jsonencode([
         for extra_host in each.value["container_extra_hosts"] : {


### PR DESCRIPTION
* This allows adding environment variables using the app.json.tpl container defintion template
* We can then reuse this container definition for tasks that won't be using an S3 environment variable file (eg. passing in environment variables from Terraform)