### PR TITLE
Allow specifying secrets in app container definition

### DIFF
--- a/container-definitions/app.json.tpl
+++ b/container-definitions/app.json.tpl
@@ -32,6 +32,9 @@
     %{ if environment != "[]" }
     "environment": "${environment},
     %{ endif }
+    %{ if secrets != "[]" }
+    "secrets": "${secrets},
+    %{ endif }
     %{ if environment_file_s3 != "" }
     "environmentFiles": [
       {

--- a/ecs-cluster-infrastructure-service-scheduled-task.tf
+++ b/ecs-cluster-infrastructure-service-scheduled-task.tf
@@ -22,6 +22,7 @@ resource "aws_ecs_task_definition" "infrastructure_ecs_cluster_service_scheduled
       entrypoint          = each.value["entrypoint"] != null ? jsonencode(each.value["entrypoint"]) : "[]"
       environment_file_s3 = "${aws_s3_bucket.infrastructure_ecs_cluster_service_environment_files[0].arn}/${each.value["container_name"]}.env"
       environment         = jsonencode([])
+      secrets             = jsonencode([])
       container_port      = 0
       extra_hosts = each.value["extra_hosts"] != null ? jsonencode([
         for extra_host in each.value["extra_hosts"] : {

--- a/ecs-cluster-infrastructure-service.tf
+++ b/ecs-cluster-infrastructure-service.tf
@@ -224,6 +224,7 @@ resource "aws_ecs_task_definition" "infrastructure_ecs_cluster_service" {
       entrypoint          = each.value["container_entrypoint"] != null ? jsonencode(each.value["container_entrypoint"]) : "[]"
       environment_file_s3 = "${aws_s3_bucket.infrastructure_ecs_cluster_service_environment_files[0].arn}/${each.key}.env"
       environment         = jsonencode([])
+      secrets             = jsonencode([])
       container_port      = each.value["container_port"] != null ? each.value["container_port"] : 0
       extra_hosts = each.value["container_extra_hosts"] != null ? jsonencode([
         for extra_host in each.value["container_extra_hosts"] : {


### PR DESCRIPTION
* This allows using secrets rather than environment variables for containers. Using `secrets` allows environment variables to be set, but they will not be exposed within docker logs or inspect.
* We can use secrets to pass in sensitive environment variables such as database credentials.