### PR TITLE
Allow multiple role ARNs and Services in Pass Role policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,8 +163,7 @@ This project creates and manages resources within an AWS account for infrastruct
 | [aws_iam_policy.infrastructure_ecs_cluster_ssm_service_setting_rw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.infrastructure_rds_monitoring](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.infrastructure_rds_s3_backups_cloudwatch_schedule_ecs_run_task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.infrastructure_rds_s3_backups_cloudwatch_schedule_pass_role_execution_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.infrastructure_rds_s3_backups_cloudwatch_schedule_pass_role_task_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.infrastructure_rds_s3_backups_cloudwatch_schedule_pass_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.infrastructure_rds_s3_backups_image_codebuild_allow_builds](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.infrastructure_rds_s3_backups_image_codebuild_cloudwatch_rw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.infrastructure_rds_s3_backups_image_codebuild_ecr_push](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
@@ -234,8 +233,7 @@ This project creates and manages resources within an AWS account for infrastruct
 | [aws_iam_role_policy_attachment.infrastructure_ecs_cluster_ssm_service_setting_rw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.infrastructure_rds_monitoring](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.infrastructure_rds_s3_backups_cloudwatch_schedule_ecs_run_task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.infrastructure_rds_s3_backups_cloudwatch_schedule_pass_role_execution_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.infrastructure_rds_s3_backups_cloudwatch_schedule_pass_role_task_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.infrastructure_rds_s3_backups_cloudwatch_schedule_pass_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.infrastructure_rds_s3_backups_image_codebuild_allow_builds](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.infrastructure_rds_s3_backups_image_codebuild_cloudwatch_rw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.infrastructure_rds_s3_backups_image_codebuild_ecr_push](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |

--- a/ecs-cluster-infrastructure-service-scheduled-task.tf
+++ b/ecs-cluster-infrastructure-service-scheduled-task.tf
@@ -123,8 +123,8 @@ resource "aws_iam_policy" "infrastructure_ecs_cluster_service_scheduled_task_pas
   policy = templatefile(
     "${path.root}/policies/pass-role.json.tpl",
     {
-      role_arn = aws_iam_role.infrastructure_ecs_cluster_service_task_execution[each.value["container_name"]].arn
-      service  = "ecs-tasks.amazonaws.com"
+      role_arns = jsonencode([aws_iam_role.infrastructure_ecs_cluster_service_task_execution[each.value["container_name"]].arn])
+      services  = jsonencode(["ecs-tasks.amazonaws.com"])
     }
   )
 }

--- a/ecs-cluster-infrastructure.tf
+++ b/ecs-cluster-infrastructure.tf
@@ -74,8 +74,8 @@ resource "aws_iam_policy" "infrastructure_ecs_cluster_pass_role_ssm_dhmc" {
   policy = templatefile(
     "${path.root}/policies/pass-role.json.tpl",
     {
-      role_arn = "arn:aws:iam::${local.aws_account_id}:role/${data.external.ssm_dhmc_setting[0].result.setting_value}",
-      service  = "ssm.amazonaws.com"
+      role_arns = jsonencode(["arn:aws:iam::${local.aws_account_id}:role/${data.external.ssm_dhmc_setting[0].result.setting_value}"])
+      services  = jsonencode(["ssm.amazonaws.com"])
     }
   )
 }

--- a/policies/pass-role.json.tpl
+++ b/policies/pass-role.json.tpl
@@ -6,12 +6,10 @@
       "Action": [
         "iam:PassRole"
       ],
-      "Resource": "${role_arn}",
+      "Resource": ${role_arns},
       "Condition": {
         "StringEquals": {
-          "iam:PassedToService": [
-            "${service}"
-          ]
+          "iam:PassedToService": ${services}
         }
       }
     }


### PR DESCRIPTION
* Prevents needing to have multiple policies when more than 1 role needs to be passed to a service