### PR TITLE
Fix log delivery KMS policy

### DIFF
--- a/policies/kms-key-policy-statements/log-delivery-allow.json.tpl
+++ b/policies/kms-key-policy-statements/log-delivery-allow.json.tpl
@@ -1,13 +1,22 @@
 %{if account_id != ""}{
+  "Effect": "Allow",
+  "Principal": {
+    "Service": [ "delivery.logs.amazonaws.com" ]
+  },
+  "Action": [
+    "kms:GenerateDataKey*",
+    "kms:Decrypt"
+  ],
+  "Resource": "*"
+},
+{
   "Effect": "Allow", 
   "Principal": {
     "Service": [ "delivery.logs.amazonaws.com" ] 
   },
   "Action": [
     "kms:Encrypt",
-    "kms:Decrypt",
     "kms:ReEncrypt*",
-    "kms:GenerateDataKey*",
     "kms:DescribeKey"
   ],
   "Resource": "*",


### PR DESCRIPTION
* GenerateDataKey* and Decrypt* is required for all resources from the `delivery.logs.amazonaws.com` service, to allow CloudFront to use the KMS key