### PR TITLE
Add CloudFront logs Athena and Glue tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ This project creates and manages resources within an AWS account for infrastruct
 | [aws_alb_target_group.infrastructure_ecs_cluster_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/alb_target_group) | resource |
 | [aws_alb_target_group.infrastructure_ecs_cluster_service_blue](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/alb_target_group) | resource |
 | [aws_alb_target_group.infrastructure_ecs_cluster_service_green](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/alb_target_group) | resource |
+| [aws_athena_workgroup.infrastructure_ecs_cluster_service_cloudfront_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/athena_workgroup) | resource |
 | [aws_athena_workgroup.infrastructure_vpc_flow_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/athena_workgroup) | resource |
 | [aws_autoscaling_group.infrastructure_ecs_cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group) | resource |
 | [aws_autoscaling_lifecycle_hook.infrastructure_ecs_cluster_termination](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_lifecycle_hook) | resource |
@@ -120,7 +121,9 @@ This project creates and manages resources within an AWS account for infrastruct
 | [aws_globalaccelerator_endpoint_group.service_loadbalancer_alb_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/globalaccelerator_endpoint_group) | resource |
 | [aws_globalaccelerator_listener.infrastructure_ecs_cluster_service_alb_http](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/globalaccelerator_listener) | resource |
 | [aws_globalaccelerator_listener.infrastructure_ecs_cluster_service_alb_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/globalaccelerator_listener) | resource |
+| [aws_glue_catalog_database.infrastructure_ecs_cluster_service_cloudfront_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/glue_catalog_database) | resource |
 | [aws_glue_catalog_database.infrastructure_vpc_flow_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/glue_catalog_database) | resource |
+| [aws_glue_catalog_table.infrastructure_ecs_cluster_service_cloudfront_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/glue_catalog_table) | resource |
 | [aws_glue_catalog_table.infrastructure_vpc_flow_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/glue_catalog_table) | resource |
 | [aws_iam_access_key.infrastructure_ecs_cluster_service_build_pipeline_buildspec_store](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_access_key) | resource |
 | [aws_iam_group.infrastructure_ecs_cluster_service_build_pipeline_buildspec_store](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_group) | resource |

--- a/ecs-cluster-infrastructure-service-cloudfront-logs-athena.tf
+++ b/ecs-cluster-infrastructure-service-cloudfront-logs-athena.tf
@@ -1,0 +1,21 @@
+resource "aws_athena_workgroup" "infrastructure_ecs_cluster_service_cloudfront_logs" {
+  for_each = {
+    for k, v in local.infrastructure_ecs_cluster_services : k => v if v["enable_cloudfront"] == true && v["cloudfront_access_logging_enabled"] == true
+  }
+
+  name = "${local.resource_prefix}-infrastructure-ecs-cluster-service-${each.key}-logs"
+
+  configuration {
+    enforce_workgroup_configuration    = true
+    publish_cloudwatch_metrics_enabled = true
+
+    result_configuration {
+      output_location = "s3://${aws_s3_bucket.infrastructure_logs[0].bucket}/${local.resource_prefix}-infrastructure-ecs-cluster-service-${each.key}-logs"
+
+      encryption_configuration {
+        encryption_option = local.infrastructure_kms_encryption ? "SSE_KMS" : "SSE_S3"
+        kms_key_arn       = local.infrastructure_kms_encryption ? aws_kms_key.infrastructure[0].arn : null
+      }
+    }
+  }
+}

--- a/ecs-cluster-infrastructure-service-cloudfront-logs-glue-tables.tf
+++ b/ecs-cluster-infrastructure-service-cloudfront-logs-glue-tables.tf
@@ -1,0 +1,47 @@
+resource "aws_glue_catalog_database" "infrastructure_ecs_cluster_service_cloudfront_logs" {
+  for_each = {
+    for k, v in local.infrastructure_ecs_cluster_services : k => v if v["enable_cloudfront"] == true && v["cloudfront_access_logging_enabled"] == true
+  }
+
+  name        = "${replace(local.resource_prefix, "-", "_")}_infrastructure_ecs_cluster_service_${replace(each.key, "-", "_")}_logs"
+  description = "Database for ${local.resource_prefix} ECS cluster service ${each.key} CloudFront log tables to be queried with Athena"
+}
+
+resource "aws_glue_catalog_table" "infrastructure_ecs_cluster_service_cloudfront_logs" {
+  for_each = {
+    for k, v in local.infrastructure_ecs_cluster_services : k => v if v["enable_cloudfront"] == true && v["cloudfront_access_logging_enabled"] == true
+  }
+
+  name          = "${replace(local.resource_prefix, "-", "_")}_infrastructure_ecs_cluster_service_${replace(each.key, "-", "_")}_logs"
+  database_name = aws_glue_catalog_database.infrastructure_ecs_cluster_service_cloudfront_logs[each.key].name
+
+  parameters = {
+    comment                  = "CloudFront logs table for ${local.resource_prefix} ECS cluster service ${each.key}"
+    EXTERNAL                 = "TRUE"
+    "skip.header.line.count" = "2"
+  }
+
+  storage_descriptor {
+    input_format  = "org.apache.hadoop.mapred.TextInputFormat"
+    output_format = "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"
+    location      = "s3://${aws_s3_bucket.infrastructure_logs[0].id}/cloudfront/infrasructure-ecs-cluster-service/${each.key}/"
+
+    ser_de_info {
+      name                  = "serde"
+      serialization_library = "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe"
+
+      parameters = {
+        "field.delim" : "\t"
+        "serialization.format" : "\t"
+      }
+    }
+
+    dynamic "columns" {
+      for_each = local.infrastructure_ecs_cluster_service_cloudfront_logs_glue_table_columns
+      content {
+        name = columns.value["name"]
+        type = columns.value["type"]
+      }
+    }
+  }
+}

--- a/locals.tf
+++ b/locals.tf
@@ -197,6 +197,7 @@ locals {
     })
   )
 
+
   enable_infrastructure_ecs_cluster_efs        = var.enable_infrastructure_ecs_cluster_efs && local.infrastructure_vpc
   ecs_cluster_efs_performance_mode             = var.ecs_cluster_efs_performance_mode
   ecs_cluster_efs_throughput_mode              = var.ecs_cluster_efs_throughput_mode
@@ -214,6 +215,41 @@ locals {
   infrastructure_ecs_cluster_services_alb_ip_allow_list             = var.infrastructure_ecs_cluster_services_alb_ip_allow_list
   enable_infrastructure_ecs_cluster_services_alb_logs               = var.enable_infrastructure_ecs_cluster_services_alb_logs && length(local.infrastructure_ecs_cluster_services) > 0
   infrastructure_ecs_cluster_services_alb_logs_retention            = var.infrastructure_ecs_cluster_services_alb_logs_retention
+  infrastructure_ecs_cluster_service_cloudfront_logs_glue_table_columns = [
+    { name = "date", type = "date" },
+    { name = "time", type = "string" },
+    { name = "x-edge-location", type = "string" },
+    { name = "bytes", type = "bigint" },
+    { name = "client_ip", type = "string" },
+    { name = "method", type = "string" },
+    { name = "host", type = "string" },
+    { name = "uri", type = "string" },
+    { name = "status", type = "int" },
+    { name = "referrer", type = "string" },
+    { name = "user_agent", type = "string" },
+    { name = "query_string", type = "string" },
+    { name = "cookie", type = "string" },
+    { name = "result_type", type = "string" },
+    { name = "request_id", type = "string" },
+    { name = "host_header", type = "string" },
+    { name = "request_protocol", type = "string" },
+    { name = "request_bytes", type = "string" },
+    { name = "time_taken", type = "float" },
+    { name = "x_forwarded_for", type = "string" },
+    { name = "ssl_protocol", type = "string" },
+    { name = "ssl_cipher", type = "string" },
+    { name = "response_result_type", type = "string" },
+    { name = "http_version", type = "string" },
+    { name = "fle_status", type = "string" },
+    { name = "fle_encrypted_fields", type = "int" },
+    { name = "client_port", type = "int" },
+    { name = "time_to_first_byte", type = "float" },
+    { name = "x_edge_detailed_result_type", type = "string" },
+    { name = "sc_content_type", type = "string" },
+    { name = "sc_content_len", type = "bigint" },
+    { name = "sc_range_start", type = "bigint" },
+    { name = "sc_range_end", type = "bigint" },
+  ]
 
   infrastructure_rds_defaults = var.infrastructure_rds_defaults
   infrastructure_rds_keys     = length(var.infrastructure_rds) > 0 ? keys(values(var.infrastructure_rds)[0]) : []


### PR DESCRIPTION
* Allows querying ECS Service CloudFront logs with Athena
* Creates an Athena workgroup, database and table with the columns required for CloudFront logs