### PR TITLE
Fix Athena result output location

### DIFF
--- a/ecs-cluster-infrastructure-service-cloudfront-logs-athena.tf
+++ b/ecs-cluster-infrastructure-service-cloudfront-logs-athena.tf
@@ -10,7 +10,7 @@ resource "aws_athena_workgroup" "infrastructure_ecs_cluster_service_cloudfront_l
     publish_cloudwatch_metrics_enabled = true
 
     result_configuration {
-      output_location = "s3://${aws_s3_bucket.infrastructure_logs[0].bucket}/${local.resource_prefix}-infrastructure-ecs-cluster-service-${each.key}-logs"
+      output_location = "s3://${aws_s3_bucket.infrastructure_logs[0].bucket}/${local.logs_bucket_athena_result_output_dir}/${local.resource_prefix}-infrastructure-ecs-cluster-service-${each.key}-cloudfront-logs"
 
       encryption_configuration {
         encryption_option = local.infrastructure_kms_encryption ? "SSE_KMS" : "SSE_S3"

--- a/locals.tf
+++ b/locals.tf
@@ -42,6 +42,7 @@ locals {
   logs_bucket_logs_source_arns = concat(
     local.infrastructure_vpc_flow_logs_s3_with_athena ? ["arn:aws:logs:${local.aws_region}:${local.aws_account_id}:*"] : []
   )
+  logs_bucket_athena_result_output_dir = "athena-result-output"
 
   route53_root_hosted_zone_domain_name      = var.route53_root_hosted_zone_domain_name
   aws_profile_name_route53_root             = var.aws_profile_name_route53_root

--- a/vpc-infrastructure-flow-logs-athena.tf
+++ b/vpc-infrastructure-flow-logs-athena.tf
@@ -8,7 +8,7 @@ resource "aws_athena_workgroup" "infrastructure_vpc_flow_logs" {
     publish_cloudwatch_metrics_enabled = true
 
     result_configuration {
-      output_location = "s3://${aws_s3_bucket.infrastructure_logs[0].bucket}/${local.infrastructure_vpc_flow_logs_s3_key_prefix}-athena-output"
+      output_location = "s3://${aws_s3_bucket.infrastructure_logs[0].bucket}/${local.logs_bucket_athena_result_output_dir}/${local.infrastructure_vpc_flow_logs_s3_key_prefix}-vpcflowlogs"
 
       encryption_configuration {
         encryption_option = local.infrastructure_kms_encryption ? "SSE_KMS" : "SSE_S3"


### PR DESCRIPTION
* Changes the directory of the Athena result output, to consolidate them into a single directory within the logs bucket. This prevents multiple oddly named directories being created within the root of the bucket