### PR TITLE
S3 to Azure Blob Storage backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ This project creates and manages resources within an AWS account for infrastruct
 | [aws_cloudwatch_event_rule.infrastructure_ecs_cluster_service_scheduled_task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_event_rule.infrastructure_rds_s3_backups_image_build_trigger_codebuild](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_event_rule.infrastructure_rds_s3_backups_scheduled_task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
+| [aws_cloudwatch_event_rule.s3_azure_blob_storage_backups_image_build_trigger_codebuild](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
+| [aws_cloudwatch_event_rule.s3_azure_blob_storage_backups_scheduled_task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_event_target.ecr_scan_event_target](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
 | [aws_cloudwatch_event_target.ecs_cluster_infrastructure_ecs_asg_diff_metric_1_min_cron](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
 | [aws_cloudwatch_event_target.ecs_cluster_infrastructure_instance_refresh](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
@@ -80,6 +82,8 @@ This project creates and manages resources within an AWS account for infrastruct
 | [aws_cloudwatch_event_target.infrastructure_ecs_cluster_service_scheduled_task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
 | [aws_cloudwatch_event_target.infrastructure_rds_s3_backups_image_build_trigger_codebuild](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
 | [aws_cloudwatch_event_target.infrastructure_rds_s3_backups_scheduled_task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
+| [aws_cloudwatch_event_target.s3_azure_blob_storage_backups_image_build_trigger_codebuild](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
+| [aws_cloudwatch_event_target.s3_azure_blob_storage_backups_scheduled_task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
 | [aws_cloudwatch_log_group.ecs_cluster_infrastructure_draining_lambda_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.ecs_cluster_infrastructure_ecs_asg_diff_metric_lambda_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.ecs_cluster_infrastructure_instance_refresh_lambda_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
@@ -89,6 +93,7 @@ This project creates and manages resources within an AWS account for infrastruct
 | [aws_cloudwatch_log_group.infrastructure_rds_exports](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.infrastructure_rds_s3_backups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.infrastructure_vpc_flow_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_cloudwatch_log_group.s3_azure_blob_storage_backups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_metric_alarm.infrastructure_ecs_cluster_asg_cpu](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_cloudwatch_metric_alarm.infrastructure_ecs_cluster_ecs_asg_diff](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_cloudwatch_metric_alarm.infrastructure_ecs_cluster_pending_task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
@@ -96,6 +101,7 @@ This project creates and manages resources within an AWS account for infrastruct
 | [aws_codebuild_project.infrastructure_ecs_cluster_logspout_image_build](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codebuild_project) | resource |
 | [aws_codebuild_project.infrastructure_ecs_cluster_service_build](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codebuild_project) | resource |
 | [aws_codebuild_project.infrastructure_rds_s3_backups_image_build](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codebuild_project) | resource |
+| [aws_codebuild_project.s3_azure_blob_storage_backups_image_build](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codebuild_project) | resource |
 | [aws_codedeploy_app.infrastructure_ecs_cluster_service_blue_green](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codedeploy_app) | resource |
 | [aws_codedeploy_deployment_config.infrastructure_ecs_cluster_service_blue_green](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codedeploy_deployment_config) | resource |
 | [aws_codedeploy_deployment_group.infrastructure_ecs_cluster_service_blue_green](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codedeploy_deployment_group) | resource |
@@ -109,8 +115,10 @@ This project creates and manages resources within an AWS account for infrastruct
 | [aws_ecr_repository.infrastructure_ecs_cluster_logspout](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository) | resource |
 | [aws_ecr_repository.infrastructure_ecs_cluster_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository) | resource |
 | [aws_ecr_repository.infrastructure_rds_s3_backups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository) | resource |
+| [aws_ecr_repository.s3_azure_blob_storage_backups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository) | resource |
 | [aws_ecs_cluster.infrastructure](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_cluster) | resource |
 | [aws_ecs_cluster.infrastrucutre_rds_tooling](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_cluster) | resource |
+| [aws_ecs_cluster.s3_azure_blob_storage_backups_tooling](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_cluster) | resource |
 | [aws_ecs_service.infrastructure_ecs_cluster_datadog_agent](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
 | [aws_ecs_service.infrastructure_ecs_cluster_logspout](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
 | [aws_ecs_service.infrastructure_ecs_cluster_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
@@ -119,6 +127,7 @@ This project creates and manages resources within an AWS account for infrastruct
 | [aws_ecs_task_definition.infrastructure_ecs_cluster_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
 | [aws_ecs_task_definition.infrastructure_ecs_cluster_service_scheduled_task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
 | [aws_ecs_task_definition.infrastructure_rds_s3_backups_scheduled_task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
+| [aws_ecs_task_definition.s3_azure_blob_storage_backups_scheduled_task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
 | [aws_efs_file_system.infrastructure_ecs_cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_file_system) | resource |
 | [aws_efs_mount_target.infrastructure_ecs_cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_mount_target) | resource |
 | [aws_eip.infrastructure_nat](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) | resource |
@@ -206,6 +215,15 @@ This project creates and manages resources within an AWS account for infrastruct
 | [aws_iam_policy.infrastructure_rds_s3_backups_task_kms_encrypt](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.infrastructure_rds_s3_backups_task_s3_list](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.infrastructure_rds_s3_backups_task_s3_write](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.s3_azure_blob_storage_backups_cloudwatch_schedule_ecs_run_task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.s3_azure_blob_storage_backups_cloudwatch_schedule_pass_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.s3_azure_blob_storage_backups_image_codebuild_allow_builds](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.s3_azure_blob_storage_backups_image_codebuild_cloudwatch_rw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.s3_azure_blob_storage_backups_image_codebuild_ecr_push](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.s3_azure_blob_storage_backups_task_execution_cloudwatch_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.s3_azure_blob_storage_backups_task_execution_ecr_pull](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.s3_azure_blob_storage_backups_task_kms_decrypt](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.s3_azure_blob_storage_backups_task_s3_read](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.ecs_cluster_infrastructure_draining_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.ecs_cluster_infrastructure_ecs_asg_diff_metric_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.ecs_cluster_infrastructure_instance_refresh_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
@@ -227,6 +245,10 @@ This project creates and manages resources within an AWS account for infrastruct
 | [aws_iam_role.infrastructure_rds_s3_backups_task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.infrastructure_rds_s3_backups_task_execution](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.infrastructure_vpc_flow_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.s3_azure_blob_storage_backups_cloudwatch_schedule](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.s3_azure_blob_storage_backups_image_codebuild](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.s3_azure_blob_storage_backups_task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.s3_azure_blob_storage_backups_task_execution](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy.infrastructure_vpc_flow_logs_allow_cloudwatch_rw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy_attachment.ecs_cluster_infrastructure_draining_ecs_container_instance_state_update_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.ecs_cluster_infrastructure_draining_kms_encrypt](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
@@ -292,6 +314,15 @@ This project creates and manages resources within an AWS account for infrastruct
 | [aws_iam_role_policy_attachment.infrastructure_rds_s3_backups_task_kms_encrypt](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.infrastructure_rds_s3_backups_task_s3_list](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.infrastructure_rds_s3_backups_task_s3_write](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.s3_azure_blob_storage_backups_cloudwatch_schedule_ecs_run_task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.s3_azure_blob_storage_backups_cloudwatch_schedule_pass_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.s3_azure_blob_storage_backups_image_codebuild_allow_builds](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.s3_azure_blob_storage_backups_image_codebuild_cloudwatch_rw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.s3_azure_blob_storage_backups_image_codebuild_ecr_push](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.s3_azure_blob_storage_backups_task_execution_cloudwatch_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.s3_azure_blob_storage_backups_task_execution_ecr_pull](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.s3_azure_blob_storage_backups_task_kms_decrypt](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.s3_azure_blob_storage_backups_task_s3_read](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_user.infrastructure_ecs_cluster_service_build_pipeline_buildspec_store](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
 | [aws_instance.infrastructure_bastion](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
 | [aws_internet_gateway.infrastructure_public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/internet_gateway) | resource |
@@ -418,6 +449,7 @@ This project creates and manages resources within an AWS account for infrastruct
 | [aws_security_group.infrastructure_elasticache](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.infrastructure_rds](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.infrastructure_rds_s3_backups_scheduled_task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group.s3_azure_blob_storage_backups_scheduled_task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group_rule.infrastructure_ec2_bastion_host_custom](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.infrastructure_ec2_bastion_host_egress_dns_tcp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.infrastructure_ec2_bastion_host_egress_dns_udp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
@@ -447,6 +479,10 @@ This project creates and manages resources within an AWS account for infrastruct
 | [aws_security_group_rule.infrastructure_rds_s3_backups_scheduled_task_egress_https_tcp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.infrastructure_rds_s3_backups_scheduled_task_egress_https_udp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.infrastructure_rds_s3_backups_scheduled_task_egress_rds](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.s3_azure_blob_storage_backups_scheduled_task_egress_dns_tcp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.s3_azure_blob_storage_backups_scheduled_task_egress_dns_udp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.s3_azure_blob_storage_backups_scheduled_task_egress_https_tcp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.s3_azure_blob_storage_backups_scheduled_task_egress_https_udp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_sns_topic.infrastructure_ecs_cluster_autoscaling_lifecycle_termination](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
 | [aws_sns_topic_subscription.ecs_cluster_infrastructure_draining_autoscaling_lifecycle_termination](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_subscription) | resource |
 | [aws_ssm_document.infrastructure_vpc_transfer_s3_download](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_document) | resource |
@@ -467,6 +503,7 @@ This project creates and manages resources within an AWS account for infrastruct
 | [terraform_data.infrastructure_ecs_cluster_service_blue_green_create_codedeploy_deployment](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [terraform_data.infrastructure_ecs_cluster_service_env_file](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [terraform_data.infrastructure_rds_s3_backups_image_build_trigger_codebuild](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
+| [terraform_data.s3_azure_blob_storage_backups_image_build_trigger_codebuild](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [archive_file.ecs_cluster_infrastructure_draining_lambda](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [archive_file.ecs_cluster_infrastructure_ecs_asg_diff_metric_lambda](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [archive_file.ecs_cluster_infrastructure_instance_refresh_lambda](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
@@ -509,6 +546,7 @@ This project creates and manages resources within an AWS account for infrastruct
 | <a name="input_enable_infrastructure_rds_backup_to_s3"></a> [enable\_infrastructure\_rds\_backup\_to\_s3](#input\_enable\_infrastructure\_rds\_backup\_to\_s3) | Enable Infrastructure RDS backups to S3. This will create a scheduled Fargate task to take SQL dumps and upload them to S3 | `bool` | n/a | yes |
 | <a name="input_enable_infrastructure_route53_hosted_zone"></a> [enable\_infrastructure\_route53\_hosted\_zone](#input\_enable\_infrastructure\_route53\_hosted\_zone) | Creates a Route53 hosted zone, where DNS records will be created for resources launched within this module. | `bool` | n/a | yes |
 | <a name="input_enable_infrastructure_vpc_transfer_s3_bucket"></a> [enable\_infrastructure\_vpc\_transfer\_s3\_bucket](#input\_enable\_infrastructure\_vpc\_transfer\_s3\_bucket) | Enable VPC transfer S3 bucket. This allows uploading/downloading files from resources within the infrastructure VPC | `bool` | n/a | yes |
+| <a name="input_enable_s3_backup_to_azure_blob_storage"></a> [enable\_s3\_backup\_to\_azure\_blob\_storage](#input\_enable\_s3\_backup\_to\_azure\_blob\_storage) | Conditionally create resources to backup S3 buckets to Azure blob storage | `bool` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment name to be used as part of the resource prefix | `string` | n/a | yes |
 | <a name="input_infrastructure_bastion_host_custom_security_group_rules"></a> [infrastructure\_bastion\_host\_custom\_security\_group\_rules](#input\_infrastructure\_bastion\_host\_custom\_security\_group\_rules) | Map of custom security group rules to add to the Infrastructure EC2 Bastion Host security group (eg. { rule-name = {type = "egress", ... }  }) | <pre>map(object({<br/>    description              = string<br/>    type                     = string<br/>    from_port                = number<br/>    to_port                  = number<br/>    protocol                 = string<br/>    source_security_group_id = optional(string, "")<br/>    cidr_blocks              = optional(list(string), [])<br/>  }))</pre> | n/a | yes |
 | <a name="input_infrastructure_datadog_api_key"></a> [infrastructure\_datadog\_api\_key](#input\_infrastructure\_datadog\_api\_key) | Datadog API key | `string` | n/a | yes |
@@ -597,6 +635,11 @@ This project creates and manages resources within an AWS account for infrastruct
 | <a name="input_infrastructure_vpc_transfer_s3_bucket_access_vpc_ids"></a> [infrastructure\_vpc\_transfer\_s3\_bucket\_access\_vpc\_ids](#input\_infrastructure\_vpc\_transfer\_s3\_bucket\_access\_vpc\_ids) | Additional VPC ids which are allowed to access the transfer S3 bucket | `list(string)` | n/a | yes |
 | <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name to be used as a prefix for all resources | `string` | n/a | yes |
 | <a name="input_route53_root_hosted_zone_domain_name"></a> [route53\_root\_hosted\_zone\_domain\_name](#input\_route53\_root\_hosted\_zone\_domain\_name) | Route53 Hosted Zone in which to delegate Infrastructure Route53 Hosted Zones. | `string` | n/a | yes |
+| <a name="input_s3_backup_to_azure_blob_storage_login_type"></a> [s3\_backup\_to\_azure\_blob\_storage\_login\_type](#input\_s3\_backup\_to\_azure\_blob\_storage\_login\_type) | Azure login type for S3 backups to blob storage | `string` | n/a | yes |
+| <a name="input_s3_backup_to_azure_blob_storage_source_and_targets"></a> [s3\_backup\_to\_azure\_blob\_storage\_source\_and\_targets](#input\_s3\_backup\_to\_azure\_blob\_storage\_source\_and\_targets) | S3 to Azure blob storage backup configuration<br/>  {<br/>    bucket-name = {<br/>      s3\_bucket\_kms\_key\_arn: The KMS Key ARN of the bucket, to add permissions to the Fargate backup container<br/>      blob\_storage\_account\_name: The Azure storage account which holds the blob storage container<br/>      blob\_storage\_container\_name: The Azure blob storage container name<br/>      cron\_expression: AWS cron expression to run the backup Fargate scheduled task<br/>    }<br/>  } | <pre>map(object({<br/>    s3_bucket_kms_key_arn       = string<br/>    blob_storage_account_name   = string<br/>    blob_storage_container_name = string<br/>    cron_expression             = string<br/>  }))</pre> | n/a | yes |
+| <a name="input_s3_backup_to_azure_blob_storage_spa_application_id"></a> [s3\_backup\_to\_azure\_blob\_storage\_spa\_application\_id](#input\_s3\_backup\_to\_azure\_blob\_storage\_spa\_application\_id) | Azure SPA Application ID for S3 backups to blob storage | `string` | n/a | yes |
+| <a name="input_s3_backup_to_azure_blob_storage_spa_client_secret"></a> [s3\_backup\_to\_azure\_blob\_storage\_spa\_client\_secret](#input\_s3\_backup\_to\_azure\_blob\_storage\_spa\_client\_secret) | Azure SPA Client Secret for S3 backups to blob storage | `string` | n/a | yes |
+| <a name="input_s3_backup_to_azure_blob_storage_tenant_id"></a> [s3\_backup\_to\_azure\_blob\_storage\_tenant\_id](#input\_s3\_backup\_to\_azure\_blob\_storage\_tenant\_id) | Azure Tenant ID for S3 backups to blob storage | `string` | n/a | yes |
 
 ## Outputs
 

--- a/buildspecs/dalmatian-s3-azure-blob-storage-backups.yml
+++ b/buildspecs/dalmatian-s3-azure-blob-storage-backups.yml
@@ -1,0 +1,24 @@
+version: 0.2
+
+phases:
+  pre_build:
+    commands:
+      - echo "Build started on $(date)"
+      - echo "Logging in to Amazon ECR..."
+      - aws ecr get-login-password --region "$AWS_DEFAULT_REGION" | docker login --username AWS --password-stdin "$AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com"
+      - |
+        if [ -n "$DOCKERHUB_USERNAME" ] && [ -n "DOCKERHUB_TOKEN" ];
+        then
+          echo "Logging into Dockerhub ...";
+          echo "$DOCKERHUB_TOKEN" | docker login --username "$DOCKERHUB_USERNAME" --password-stdin;
+        fi;
+      - echo Building s3-azure-blob-storage-backups docker image ...
+      - docker build -t s3-azure-blob-storage-backups:latest .
+  build:
+    commands:
+      - echo Adding ECR repo tag...
+      - docker tag s3-azure-blob-storage-backups:latest "$REPOSITORY_URI:latest"
+  post_build:
+    commands:
+      - echo Pushing the Docker image...
+      - docker push "$REPOSITORY_URI:latest"

--- a/locals.tf
+++ b/locals.tf
@@ -266,6 +266,14 @@ locals {
     "redis" = 6379
   }
 
+  enable_s3_backup_to_azure_blob_storage                           = var.enable_s3_backup_to_azure_blob_storage
+  s3_backup_to_azure_blob_storage_login_type                       = var.s3_backup_to_azure_blob_storage_login_type
+  s3_backup_to_azure_blob_storage_spa_application_id               = var.s3_backup_to_azure_blob_storage_spa_application_id
+  s3_backup_to_azure_blob_storage_spa_client_secret                = var.s3_backup_to_azure_blob_storage_spa_client_secret
+  s3_backup_to_azure_blob_storage_tenant_id                        = var.s3_backup_to_azure_blob_storage_tenant_id
+  s3_backup_to_azure_blob_storage_source_and_targets               = var.s3_backup_to_azure_blob_storage_source_and_targets
+  s3_backup_to_azure_blob_storage_backups_tooling_ecs_cluster_name = "${local.resource_prefix}-s3-azure-blob-storage-backups-tooling"
+
   custom_route53_hosted_zones = var.custom_route53_hosted_zones
 
   custom_s3_buckets = var.custom_s3_buckets

--- a/s3-azure-blob-storage-backups-cloudwatch-logs.tf
+++ b/s3-azure-blob-storage-backups-cloudwatch-logs.tf
@@ -1,0 +1,8 @@
+resource "aws_cloudwatch_log_group" "s3_azure_blob_storage_backups" {
+  for_each = local.enable_s3_backup_to_azure_blob_storage ? local.s3_backup_to_azure_blob_storage_source_and_targets : {}
+
+  name              = "${local.resource_prefix}-s3-azure-blob-storage-backups-${each.key}"
+  retention_in_days = 30
+  kms_key_id        = local.infrastructure_kms_encryption ? aws_kms_key.infrastructure[0].arn : null
+  skip_destroy      = true
+}

--- a/s3-azure-blob-storage-backups-ecr.tf
+++ b/s3-azure-blob-storage-backups-ecr.tf
@@ -1,0 +1,17 @@
+resource "aws_ecr_repository" "s3_azure_blob_storage_backups" {
+  count = local.enable_s3_backup_to_azure_blob_storage ? 1 : 0
+
+  name = "${local.resource_prefix}-s3-azure-blob-storage-backups"
+
+  #tfsec:ignore:aws-ecr-enforce-immutable-repository
+  image_tag_mutability = "MUTABLE"
+
+  encryption_configuration {
+    encryption_type = local.infrastructure_kms_encryption ? "KMS" : "AES256"
+    kms_key         = local.infrastructure_kms_encryption ? aws_kms_key.infrastructure[0].arn : null
+  }
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}

--- a/s3-azure-blob-storage-backups-image-codebuild.tf
+++ b/s3-azure-blob-storage-backups-image-codebuild.tf
@@ -1,0 +1,144 @@
+resource "aws_iam_role" "s3_azure_blob_storage_backups_image_codebuild" {
+  count = local.enable_s3_backup_to_azure_blob_storage ? 1 : 0
+
+  name        = "${local.resource_prefix}-${substr(sha512("s3-azure-blob-storage-backups-image-codebuild"), 0, 6)}"
+  description = "${local.resource_prefix}-s3-azure-blob-storage-backups-image-codebuild"
+  assume_role_policy = templatefile(
+    "${path.root}/policies/assume-roles/service-principle-standard.json.tpl",
+    { services = jsonencode(["codebuild.amazonaws.com", "events.amazonaws.com"]) }
+  )
+}
+
+resource "aws_iam_policy" "s3_azure_blob_storage_backups_image_codebuild_cloudwatch_rw" {
+  count = local.enable_s3_backup_to_azure_blob_storage ? 1 : 0
+
+  name        = "${local.resource_prefix}-${substr(sha512("s3-azure-blob-storage-backups-image-codebuild-cloudwatch-rw"), 0, 6)}"
+  description = "${local.resource_prefix}-s3-azure-blob-storage-backups-image-codebuild-cloudwatch-rw"
+  policy      = templatefile("${path.root}/policies/cloudwatch-logs-rw.json.tpl", {})
+}
+
+resource "aws_iam_role_policy_attachment" "s3_azure_blob_storage_backups_image_codebuild_cloudwatch_rw" {
+  count = local.enable_s3_backup_to_azure_blob_storage ? 1 : 0
+
+  role       = aws_iam_role.s3_azure_blob_storage_backups_image_codebuild[0].name
+  policy_arn = aws_iam_policy.s3_azure_blob_storage_backups_image_codebuild_cloudwatch_rw[0].arn
+}
+
+resource "aws_iam_policy" "s3_azure_blob_storage_backups_image_codebuild_allow_builds" {
+  count = local.enable_s3_backup_to_azure_blob_storage ? 1 : 0
+
+  name        = "${local.resource_prefix}-${substr(sha512("s3-azure-blob-storage-backups-image-codebuild-allow-builds"), 0, 6)}"
+  description = "${local.resource_prefix}-s3-azure-blob-storage-backups-image-codebuild-allow-builds"
+  policy      = templatefile("${path.root}/policies/codebuild-allow-builds.json.tpl", {})
+}
+
+resource "aws_iam_role_policy_attachment" "s3_azure_blob_storage_backups_image_codebuild_allow_builds" {
+  count = local.enable_s3_backup_to_azure_blob_storage ? 1 : 0
+
+  role       = aws_iam_role.s3_azure_blob_storage_backups_image_codebuild[0].name
+  policy_arn = aws_iam_policy.s3_azure_blob_storage_backups_image_codebuild_allow_builds[0].arn
+}
+
+resource "aws_iam_policy" "s3_azure_blob_storage_backups_image_codebuild_ecr_push" {
+  count = local.enable_s3_backup_to_azure_blob_storage ? 1 : 0
+
+  name        = "${local.resource_prefix}-${substr(sha512("s3-azure-blob-storage-backups-image-codebuild-ecr-push"), 0, 6)}"
+  description = "${local.resource_prefix}-s3-azure-blob-storage-backups-image-codebuild-ecr-push"
+  policy = templatefile(
+    "${path.root}/policies/ecr-push.json.tpl",
+    { ecr_repository_arn = aws_ecr_repository.s3_azure_blob_storage_backups[0].arn }
+  )
+}
+
+resource "aws_iam_role_policy_attachment" "s3_azure_blob_storage_backups_image_codebuild_ecr_push" {
+  count = local.enable_s3_backup_to_azure_blob_storage ? 1 : 0
+
+  role       = aws_iam_role.s3_azure_blob_storage_backups_image_codebuild[0].name
+  policy_arn = aws_iam_policy.s3_azure_blob_storage_backups_image_codebuild_ecr_push[0].arn
+}
+
+resource "aws_codebuild_project" "s3_azure_blob_storage_backups_image_build" {
+  count = local.enable_s3_backup_to_azure_blob_storage ? 1 : 0
+
+  name          = "${local.resource_prefix}-s3-azure-blob-storage-backups-image-build"
+  description   = "${local.resource_prefix} S3 Azure Blob Storage Backups Image Build"
+  build_timeout = "20"
+  service_role  = aws_iam_role.s3_azure_blob_storage_backups_image_codebuild[0].arn
+
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
+
+  environment {
+    compute_type    = "BUILD_GENERAL1_SMALL"
+    image           = "aws/codebuild/standard:7.0"
+    type            = "LINUX_CONTAINER"
+    privileged_mode = true
+
+    environment_variable {
+      name  = "AWS_ACCOUNT_ID"
+      value = local.aws_account_id
+    }
+
+    environment_variable {
+      name  = "REPOSITORY_URI"
+      value = aws_ecr_repository.s3_azure_blob_storage_backups[0].repository_url
+    }
+
+    environment_variable {
+      name  = "DOCKERHUB_USERNAME"
+      value = local.infrastructure_dockerhub_username
+    }
+
+    environment_variable {
+      name  = "DOCKERHUB_TOKEN"
+      value = local.infrastructure_dockerhub_token
+    }
+  }
+
+  source {
+    type            = "GITHUB"
+    location        = "https://github.com/dxw/s3-to-azure"
+    git_clone_depth = 1
+    buildspec       = templatefile("${path.root}/buildspecs/dalmatian-sql-backup.yml", {})
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.s3_azure_blob_storage_backups_image_codebuild_cloudwatch_rw,
+    aws_iam_role_policy_attachment.s3_azure_blob_storage_backups_image_codebuild_allow_builds,
+    aws_iam_role_policy_attachment.s3_azure_blob_storage_backups_image_codebuild_ecr_push,
+  ]
+}
+
+resource "terraform_data" "s3_azure_blob_storage_backups_image_build_trigger_codebuild" {
+  count = local.enable_s3_backup_to_azure_blob_storage ? 1 : 0
+
+  triggers_replace = [
+    md5(templatefile("${path.root}/buildspecs/dalmatian-s3-azure-blob-storage-backups.yml", {})),
+  ]
+
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+    command     = <<EOF
+      ${path.root}/local-exec-scripts/trigger-codedeploy-project.sh \
+      -n "${aws_codebuild_project.s3_azure_blob_storage_backups_image_build[0].name}"
+    EOF
+  }
+}
+
+resource "aws_cloudwatch_event_rule" "s3_azure_blob_storage_backups_image_build_trigger_codebuild" {
+  count = local.enable_s3_backup_to_azure_blob_storage ? 1 : 0
+
+  name                = "${local.resource_prefix_hash}-s3-azure-blob-storage-bkps-img-build-trigger-codebuild"
+  description         = "${local.resource_prefix} S3 Azure blob storage backups Image Build Trigger CodeBuild"
+  schedule_expression = "rate(24 hours)"
+}
+
+resource "aws_cloudwatch_event_target" "s3_azure_blob_storage_backups_image_build_trigger_codebuild" {
+  count = local.enable_s3_backup_to_azure_blob_storage ? 1 : 0
+
+  target_id = "${local.resource_prefix_hash}-s3-azure-blob-storage-bkps-img-build-trigger-codebuild"
+  rule      = aws_cloudwatch_event_rule.s3_azure_blob_storage_backups_image_build_trigger_codebuild[0].name
+  arn       = aws_codebuild_project.s3_azure_blob_storage_backups_image_build[0].id
+  role_arn  = aws_iam_role.s3_azure_blob_storage_backups_image_codebuild[0].arn
+}

--- a/s3-azure-blob-storage-backups-scheduled-task.tf
+++ b/s3-azure-blob-storage-backups-scheduled-task.tf
@@ -1,0 +1,92 @@
+resource "aws_iam_role" "s3_azure_blob_storage_backups_cloudwatch_schedule" {
+  for_each = local.enable_s3_backup_to_azure_blob_storage ? local.s3_backup_to_azure_blob_storage_source_and_targets : {}
+
+  name        = "${local.resource_prefix}-${substr(sha512("s3-azure-blob-storage-backups-cloudwatch-schedule-${each.key}"), 0, 6)}"
+  description = "${local.resource_prefix}-s3-azure-blob-storage-backups-${each.key}"
+  assume_role_policy = templatefile(
+    "${path.root}/policies/assume-roles/service-principle-standard.json.tpl",
+    { services = jsonencode(["events.amazonaws.com"]) }
+  )
+}
+
+resource "aws_iam_policy" "s3_azure_blob_storage_backups_cloudwatch_schedule_ecs_run_task" {
+  for_each = local.enable_s3_backup_to_azure_blob_storage ? local.s3_backup_to_azure_blob_storage_source_and_targets : {}
+
+  name        = "${local.resource_prefix}-${substr(sha512("s3-azure-blob-storage-backups-cloudwatch-schedule-${each.key}-ecs-run-task"), 0, 6)}"
+  description = "${local.resource_prefix}-s3-azure-blob-storage-backups-cloudwatch-schedule-${each.key}-ecs-run-task"
+  policy      = templatefile("${path.root}/policies/ecs-run-task.json.tpl", {})
+}
+
+resource "aws_iam_role_policy_attachment" "s3_azure_blob_storage_backups_cloudwatch_schedule_ecs_run_task" {
+  for_each = local.enable_s3_backup_to_azure_blob_storage ? local.s3_backup_to_azure_blob_storage_source_and_targets : {}
+
+  role       = aws_iam_role.s3_azure_blob_storage_backups_cloudwatch_schedule[each.key].name
+  policy_arn = aws_iam_policy.s3_azure_blob_storage_backups_cloudwatch_schedule_ecs_run_task[each.key].arn
+}
+
+resource "aws_iam_policy" "s3_azure_blob_storage_backups_cloudwatch_schedule_pass_role" {
+  for_each = local.enable_s3_backup_to_azure_blob_storage ? local.s3_backup_to_azure_blob_storage_source_and_targets : {}
+
+  name        = "${local.resource_prefix}-${substr(sha512("s3-azure-blob-storage-backups-cloudwatch-schedule-${each.key}-pass-role-execution-role"), 0, 6)}"
+  description = "${local.resource_prefix}-s3-azure-blob-storage-backups-cloudwatch-schedule-${each.key}-pass-role-execution-role"
+  policy = templatefile(
+    "${path.root}/policies/pass-role.json.tpl",
+    {
+      role_arns = jsonencode([
+        aws_iam_role.s3_azure_blob_storage_backups_task_execution[each.key].arn,
+        aws_iam_role.s3_azure_blob_storage_backups_task[each.key].arn,
+      ])
+      services = jsonencode(["ecs-tasks.amazonaws.com"])
+    }
+  )
+}
+
+resource "aws_iam_role_policy_attachment" "s3_azure_blob_storage_backups_cloudwatch_schedule_pass_role" {
+  for_each = local.enable_s3_backup_to_azure_blob_storage ? local.s3_backup_to_azure_blob_storage_source_and_targets : {}
+
+  role       = aws_iam_role.s3_azure_blob_storage_backups_cloudwatch_schedule[each.key].name
+  policy_arn = aws_iam_policy.s3_azure_blob_storage_backups_cloudwatch_schedule_pass_role[each.key].arn
+}
+
+resource "aws_cloudwatch_event_rule" "s3_azure_blob_storage_backups_scheduled_task" {
+  for_each = local.enable_s3_backup_to_azure_blob_storage ? local.s3_backup_to_azure_blob_storage_source_and_targets : {}
+
+  name                = "${local.resource_prefix}-s3-azure-blob-storage-backups-${each.key}"
+  description         = "Run ${local.resource_prefix}-s3-azure-blob-storage-backups-cloudwatch-schedule-${each.key} task at a scheduled time (${each.value["cron_expression"]})"
+  schedule_expression = each.value["cron_expression"]
+}
+
+resource "aws_cloudwatch_event_target" "s3_azure_blob_storage_backups_scheduled_task" {
+  for_each = local.enable_s3_backup_to_azure_blob_storage ? local.s3_backup_to_azure_blob_storage_source_and_targets : {}
+
+  target_id = "${local.resource_prefix}-s3-azure-blob-storage-backups-${each.key}"
+  rule      = aws_cloudwatch_event_rule.s3_azure_blob_storage_backups_scheduled_task[each.key].name
+  arn       = aws_ecs_cluster.s3_azure_blob_storage_backups_tooling[0].arn
+  role_arn  = aws_iam_role.s3_azure_blob_storage_backups_cloudwatch_schedule[each.key].arn
+  input     = jsonencode({})
+
+  ecs_target {
+    task_count          = 1
+    task_definition_arn = aws_ecs_task_definition.s3_azure_blob_storage_backups_scheduled_task[each.key].arn
+    launch_type         = "FARGATE"
+    platform_version    = "1.4.0"
+    propagate_tags      = "TASK_DEFINITION"
+
+    network_configuration {
+      subnets = local.infrastructure_vpc_network_enable_private ? [
+        for subnet in aws_subnet.infrastructure_private : subnet.id
+        ] : local.infrastructure_vpc_network_enable_public ? [
+        for subnet in aws_subnet.infrastructure_public : subnet.id
+      ] : null
+      assign_public_ip = local.infrastructure_vpc_network_enable_private ? false : local.infrastructure_vpc_network_enable_public ? true : false
+      security_groups = [
+        aws_security_group.s3_azure_blob_storage_backups_scheduled_task[0].id,
+      ]
+    }
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.s3_azure_blob_storage_backups_cloudwatch_schedule_ecs_run_task,
+    aws_iam_role_policy_attachment.s3_azure_blob_storage_backups_cloudwatch_schedule_pass_role,
+  ]
+}

--- a/s3-azure-blob-storage-backups-security-group.tf
+++ b/s3-azure-blob-storage-backups-security-group.tf
@@ -1,0 +1,65 @@
+resource "aws_security_group" "s3_azure_blob_storage_backups_scheduled_task" {
+  count = local.enable_s3_backup_to_azure_blob_storage ? 1 : 0
+
+  name        = "${local.resource_prefix}-s3-azure-blob-storage-backups-scheduled-task"
+  description = "S3 Azure blob storage backups scheduled task"
+  vpc_id      = aws_vpc.infrastructure[0].id
+}
+
+resource "aws_security_group_rule" "s3_azure_blob_storage_backups_scheduled_task_egress_https_tcp" {
+  count = local.enable_s3_backup_to_azure_blob_storage ? 1 : 0
+
+  description = "Allow HTTPS tcp outbound"
+  type        = "egress"
+  from_port   = 443
+  to_port     = 443
+  protocol    = "tcp"
+  # tfsec:ignore:aws-ec2-no-public-egress-sgr
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.s3_azure_blob_storage_backups_scheduled_task[0].id
+}
+
+resource "aws_security_group_rule" "s3_azure_blob_storage_backups_scheduled_task_egress_https_udp" {
+  count = local.enable_s3_backup_to_azure_blob_storage ? 1 : 0
+
+  description = "Allow HTTPS udp outbound"
+  type        = "egress"
+  from_port   = 443
+  to_port     = 443
+  protocol    = "udp"
+  # tfsec:ignore:aws-ec2-no-public-egress-sgr
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.s3_azure_blob_storage_backups_scheduled_task[0].id
+}
+
+resource "aws_security_group_rule" "s3_azure_blob_storage_backups_scheduled_task_egress_dns_tcp" {
+  count = local.enable_s3_backup_to_azure_blob_storage ? 1 : 0
+
+  description = "Allow DNS tcp outbound to AWS"
+  type        = "egress"
+  from_port   = 53
+  to_port     = 53
+  protocol    = "tcp"
+  cidr_blocks = local.infrastructure_ecs_cluster_publicly_avaialble ? [
+    for subnet in aws_subnet.infrastructure_public : subnet.cidr_block
+    ] : [
+    for subnet in aws_subnet.infrastructure_private : subnet.cidr_block
+  ]
+  security_group_id = aws_security_group.s3_azure_blob_storage_backups_scheduled_task[0].id
+}
+
+resource "aws_security_group_rule" "s3_azure_blob_storage_backups_scheduled_task_egress_dns_udp" {
+  count = local.enable_s3_backup_to_azure_blob_storage ? 1 : 0
+
+  description = "Allow DNS udp outbound to AWS"
+  type        = "egress"
+  from_port   = 53
+  to_port     = 53
+  protocol    = "udp"
+  cidr_blocks = local.infrastructure_ecs_cluster_publicly_avaialble ? [
+    for subnet in aws_subnet.infrastructure_public : subnet.cidr_block
+    ] : [
+    for subnet in aws_subnet.infrastructure_private : subnet.cidr_block
+  ]
+  security_group_id = aws_security_group.s3_azure_blob_storage_backups_scheduled_task[0].id
+}

--- a/s3-azure-blob-storage-backups-task-definition.tf
+++ b/s3-azure-blob-storage-backups-task-definition.tf
@@ -1,0 +1,158 @@
+resource "aws_iam_role" "s3_azure_blob_storage_backups_task_execution" {
+  for_each = local.enable_s3_backup_to_azure_blob_storage ? local.s3_backup_to_azure_blob_storage_source_and_targets : {}
+
+  name        = "${local.resource_prefix}-${substr(sha512("s3-azure-blob-storage-backups-task-execution-${each.key}"), 0, 6)}"
+  description = "${local.resource_prefix}-s3-azure-blob-storage-backups-task-execution-${each.key}"
+  assume_role_policy = templatefile(
+    "${path.root}/policies/assume-roles/service-principle-standard.json.tpl",
+    { services = jsonencode(["ecs-tasks.amazonaws.com"]) }
+  )
+}
+
+resource "aws_iam_policy" "s3_azure_blob_storage_backups_task_execution_ecr_pull" {
+  for_each = local.enable_s3_backup_to_azure_blob_storage ? local.s3_backup_to_azure_blob_storage_source_and_targets : {}
+
+  name        = "${local.resource_prefix}-${substr(sha512("s3-azure-blob-storage-backups-task-execution-${each.key}-ecr-pull"), 0, 6)}"
+  description = "${local.resource_prefix}-s3-azure-blob-storage-backups-task-execution-${each.key}-ecr-pull"
+  policy = templatefile(
+    "${path.root}/policies/ecr-pull.json.tpl",
+    { ecr_repository_arn = aws_ecr_repository.s3_azure_blob_storage_backups[0].arn }
+  )
+}
+
+resource "aws_iam_role_policy_attachment" "s3_azure_blob_storage_backups_task_execution_ecr_pull" {
+  for_each = local.enable_s3_backup_to_azure_blob_storage ? local.s3_backup_to_azure_blob_storage_source_and_targets : {}
+
+  role       = aws_iam_role.s3_azure_blob_storage_backups_task_execution[each.key].name
+  policy_arn = aws_iam_policy.s3_azure_blob_storage_backups_task_execution_ecr_pull[each.key].arn
+}
+
+resource "aws_iam_policy" "s3_azure_blob_storage_backups_task_execution_cloudwatch_logs" {
+  for_each = local.enable_s3_backup_to_azure_blob_storage ? local.s3_backup_to_azure_blob_storage_source_and_targets : {}
+
+  name        = "${local.resource_prefix}-${substr(sha512("s3-azure-blob-storage-backups-task-execution-${each.key}-cloudwatch-logs"), 0, 6)}"
+  description = "${local.resource_prefix}-s3-azure-blob-storage-backups-task-execution-${each.key}-cloudwatch-logs"
+  policy      = templatefile("${path.root}/policies/cloudwatch-logs-rw.json.tpl", {})
+}
+
+resource "aws_iam_role_policy_attachment" "s3_azure_blob_storage_backups_task_execution_cloudwatch_logs" {
+  for_each = local.enable_s3_backup_to_azure_blob_storage ? local.s3_backup_to_azure_blob_storage_source_and_targets : {}
+
+  role       = aws_iam_role.s3_azure_blob_storage_backups_task_execution[each.key].name
+  policy_arn = aws_iam_policy.s3_azure_blob_storage_backups_task_execution_cloudwatch_logs[each.key].arn
+}
+
+resource "aws_iam_role" "s3_azure_blob_storage_backups_task" {
+  for_each = local.enable_s3_backup_to_azure_blob_storage ? local.s3_backup_to_azure_blob_storage_source_and_targets : {}
+
+  name        = "${local.resource_prefix}-${substr(sha512("s3-azure-blob-storage-backups-task-${each.key}"), 0, 6)}"
+  description = "${local.resource_prefix}-s3-azure-blob-storage-backups-task-${each.key}"
+  assume_role_policy = templatefile(
+    "${path.root}/policies/assume-roles/service-principle-standard.json.tpl",
+    { services = jsonencode(["ecs-tasks.amazonaws.com"]) }
+  )
+}
+
+resource "aws_iam_policy" "s3_azure_blob_storage_backups_task_s3_read" {
+  for_each = local.enable_s3_backup_to_azure_blob_storage ? local.s3_backup_to_azure_blob_storage_source_and_targets : {}
+
+  name        = "${local.resource_prefix}-${substr(sha512("s3-azure-blob-storage-backups-task-${each.key}-s3-read"), 0, 6)}"
+  description = "${local.resource_prefix}-s3-azure-blob-storage-backups-task-${each.key}-s3-read"
+  policy = templatefile("${path.root}/policies/s3-object-read.json.tpl", {
+    bucket_arn = "arn:aws:s3:::${each.key}"
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "s3_azure_blob_storage_backups_task_s3_read" {
+  for_each = local.enable_s3_backup_to_azure_blob_storage ? local.s3_backup_to_azure_blob_storage_source_and_targets : {}
+
+  role       = aws_iam_role.s3_azure_blob_storage_backups_task[each.key].name
+  policy_arn = aws_iam_policy.s3_azure_blob_storage_backups_task_s3_read[each.key].arn
+}
+
+resource "aws_iam_policy" "s3_azure_blob_storage_backups_task_kms_decrypt" {
+  for_each = local.enable_s3_backup_to_azure_blob_storage ? local.s3_backup_to_azure_blob_storage_source_and_targets : {}
+
+  name        = "${local.resource_prefix}-${substr(sha512("s3-azure-blob-storage-backups-task-${each.key}-kms-decrypt"), 0, 6)}"
+  description = "${local.resource_prefix}-s3-azure-blob-storage-backups-task-${each.key}-kms-decrypt"
+  policy = templatefile(
+    "${path.root}/policies/kms-decrypt.json.tpl",
+    { kms_key_arn = each.value["s3_bucket_kms_key_arn"] }
+  )
+}
+
+resource "aws_iam_role_policy_attachment" "s3_azure_blob_storage_backups_task_kms_decrypt" {
+  for_each = local.enable_s3_backup_to_azure_blob_storage ? local.s3_backup_to_azure_blob_storage_source_and_targets : {}
+
+  role       = aws_iam_role.s3_azure_blob_storage_backups_task[each.key].name
+  policy_arn = aws_iam_policy.s3_azure_blob_storage_backups_task_kms_decrypt[each.key].arn
+}
+
+resource "aws_ecs_task_definition" "s3_azure_blob_storage_backups_scheduled_task" {
+  for_each = local.enable_s3_backup_to_azure_blob_storage ? local.s3_backup_to_azure_blob_storage_source_and_targets : {}
+
+  family = "${local.resource_prefix}-s3-azure-blob-storage-backups-${each.key}"
+  container_definitions = templatefile(
+    "./container-definitions/app.json.tpl",
+    {
+      container_name      = "s3-azure-blob-storage-backups-${each.key}"
+      image               = aws_ecr_repository.s3_azure_blob_storage_backups[0].repository_url
+      entrypoint          = jsonencode(["/bin/bash", "-c", "/entrypoint"])
+      command             = jsonencode([])
+      environment_file_s3 = ""
+      environment = jsonencode([
+        {
+          name  = "AZCOPY_AUTO_LOGIN_TYPE",
+          value = local.s3_backup_to_azure_blob_storage_login_type
+        },
+        {
+          name  = "AZCOPY_SPA_APPLICATION_ID",
+          value = local.s3_backup_to_azure_blob_storage_spa_application_id
+        },
+        {
+          name  = "AZCOPY_SPA_CLIENT_SECRET",
+          value = local.s3_backup_to_azure_blob_storage_spa_client_secret
+        },
+        {
+          name  = "AZCOPY_TENANT_ID"
+          value = local.s3_backup_to_azure_blob_storage_tenant_id
+        },
+        {
+          name  = "SOURCE"
+          value = "https://${each.key}.s3.${local.aws_region}.amazonaws.com"
+        },
+        {
+          name  = "DESTINATION"
+          value = "https://${each.value["blob_storage_account_name"]}.blob.core.windows.net/${each.value["blob_storage_container_name"]}"
+        }
+      ])
+      secrets        = jsonencode([])
+      container_port = 0
+      extra_hosts    = jsonencode([])
+      volumes        = jsonencode([])
+      linux_parameters = jsonencode({
+        initProcessEnabled = false
+      })
+      security_options      = jsonencode([])
+      syslog_address        = ""
+      syslog_tag            = ""
+      cloudwatch_log_group  = aws_cloudwatch_log_group.s3_azure_blob_storage_backups[each.key].name
+      awslogs_stream_prefix = "${local.resource_prefix}-s3-azure-blob-storage-backups-${each.key}"
+      region                = local.aws_region
+    }
+  )
+  execution_role_arn       = aws_iam_role.s3_azure_blob_storage_backups_task_execution[each.key].arn
+  task_role_arn            = aws_iam_role.s3_azure_blob_storage_backups_task[each.key].arn
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  memory                   = 1024
+  cpu                      = 512
+
+  depends_on = [
+    aws_iam_role_policy_attachment.s3_azure_blob_storage_backups_task_execution_ecr_pull,
+    aws_iam_role_policy_attachment.s3_azure_blob_storage_backups_task_execution_cloudwatch_logs,
+    aws_iam_role_policy_attachment.s3_azure_blob_storage_backups_task_s3_read,
+    aws_iam_role_policy_attachment.s3_azure_blob_storage_backups_task_kms_decrypt,
+    terraform_data.s3_azure_blob_storage_backups_image_build_trigger_codebuild,
+  ]
+}

--- a/s3-azure-blob-storage-backups-tooling-ecs-cluster.tf
+++ b/s3-azure-blob-storage-backups-tooling-ecs-cluster.tf
@@ -1,0 +1,26 @@
+resource "aws_ecs_cluster" "s3_azure_blob_storage_backups_tooling" {
+  count = local.enable_s3_backup_to_azure_blob_storage ? 1 : 0
+
+  name = local.s3_backup_to_azure_blob_storage_backups_tooling_ecs_cluster_name
+
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
+
+  dynamic "configuration" {
+    for_each = local.infrastructure_ecs_cluster_enable_execute_command_logging ? [1] : []
+    content {
+      execute_command_configuration {
+        kms_key_id = local.infrastructure_kms_encryption ? aws_kms_key.infrastructure[0].arn : null
+        logging    = "OVERRIDE"
+
+        log_configuration {
+          s3_bucket_encryption_enabled = true
+          s3_bucket_name               = aws_s3_bucket.infrastructure_logs[0].id
+          s3_key_prefix                = "ecs-exec"
+        }
+      }
+    }
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -904,6 +904,51 @@ variable "custom_s3_buckets" {
   }))
 }
 
+variable "enable_s3_backup_to_azure_blob_storage" {
+  description = "Conditionally create resources to backup S3 buckets to Azure blob storage"
+  type        = bool
+}
+
+variable "s3_backup_to_azure_blob_storage_login_type" {
+  description = "Azure login type for S3 backups to blob storage"
+  type        = string
+}
+
+variable "s3_backup_to_azure_blob_storage_spa_application_id" {
+  description = "Azure SPA Application ID for S3 backups to blob storage"
+  type        = string
+}
+
+variable "s3_backup_to_azure_blob_storage_spa_client_secret" {
+  description = "Azure SPA Client Secret for S3 backups to blob storage"
+  type        = string
+}
+
+variable "s3_backup_to_azure_blob_storage_tenant_id" {
+  description = "Azure Tenant ID for S3 backups to blob storage"
+  type        = string
+}
+
+variable "s3_backup_to_azure_blob_storage_source_and_targets" {
+  description = <<EOT
+  S3 to Azure blob storage backup configuration
+  {
+    bucket-name = {
+      s3_bucket_kms_key_arn: The KMS Key ARN of the bucket, to add permissions to the Fargate backup container
+      blob_storage_account_name: The Azure storage account which holds the blob storage container
+      blob_storage_container_name: The Azure blob storage container name
+      cron_expression: AWS cron expression to run the backup Fargate scheduled task
+    }
+  }
+  EOT
+  type = map(object({
+    s3_bucket_kms_key_arn       = string
+    blob_storage_account_name   = string
+    blob_storage_container_name = string
+    cron_expression             = string
+  }))
+}
+
 variable "enable_cloudformatian_s3_template_store" {
   description = "Creates an S3 bucket to store custom CloudFormation templates, which can then be referenced in `custom_cloudformation_stacks`. A user with RW access to the bucket is also created."
   type        = bool


### PR DESCRIPTION
* Conditionally creates resources to run a scheduled task that backs up given S3 backups to an Azure Blob Storage Container
* CodeBuild is used to pull the dxw/s3-to-azure repo, build the image and push it to ECR
* Scheduled tasks (Fargate conatiners using the s3-to-azure image) are then created for each given S3 bucket, to backup to Azure
* Each S3 bucket can be given a different Azure Storage Account / Container target, and also be ran at different chosen cron expressions
* Permissions for the S3 buckets are directly added to the Fargate task role. The Azure permissions need to be provided (eg. Tenant ID, App ID and Secret)