### PR TITLE
Fix custom S3 bucket default certificate condition

### DIFF
--- a/s3-custom-buckets-cloudfront.tf
+++ b/s3-custom-buckets-cloudfront.tf
@@ -13,7 +13,7 @@ resource "aws_cloudfront_distribution" "custom_s3_buckets" {
 
   viewer_certificate {
     acm_certificate_arn            = each.value["cloudfront_decicated_distribution_tls_certificate_arn"] != null ? each.value["cloudfront_decicated_distribution_tls_certificate_arn"] : local.enable_infrastructure_wildcard_certificate ? aws_acm_certificate_validation.infrastructure_wildcard_us_east_1[0].certificate_arn : null
-    cloudfront_default_certificate = local.enable_infrastructure_wildcard_certificate && each.value["cloudfront_decicated_distribution_tls_certificate_arn"] == null ? null : true
+    cloudfront_default_certificate = local.enable_infrastructure_wildcard_certificate && each.value["cloudfront_decicated_distribution_tls_certificate_arn"] != null ? null : true
     minimum_protocol_version       = local.enable_infrastructure_wildcard_certificate || each.value["cloudfront_decicated_distribution_tls_certificate_arn"] != null ? "TLSv1.2_2021" : null
     ssl_support_method             = "sni-only"
   }


### PR DESCRIPTION
* We only want to use a default certificate if there is neither an infrastructure wildcard certifcate, or specified certificate ARN