### PR TITLE
Fix: Add SSM Create channels policy to RDS Tooling task role

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ This project creates and manages resources within an AWS account for infrastruct
 | [aws_iam_policy.infrastructure_rds_tooling_task_execution_ecr_pull](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.infrastructure_rds_tooling_task_execution_get_secret_value](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.infrastructure_rds_tooling_task_kms_encrypt](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.infrastructure_rds_tooling_task_ssm_create_channels](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.ecs_cluster_infrastructure_draining_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.ecs_cluster_infrastructure_ecs_asg_diff_metric_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.ecs_cluster_infrastructure_instance_refresh_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
@@ -289,6 +290,7 @@ This project creates and manages resources within an AWS account for infrastruct
 | [aws_iam_role_policy_attachment.infrastructure_rds_tooling_task_execution_ecr_pull](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.infrastructure_rds_tooling_task_execution_get_secret_value](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.infrastructure_rds_tooling_task_kms_encrypt](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.infrastructure_rds_tooling_task_ssm_create_channels](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_instance.infrastructure_bastion](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
 | [aws_internet_gateway.infrastructure_public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/internet_gateway) | resource |
 | [aws_kms_alias.custom_s3_buckets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |

--- a/rds-infrastructure-tooling-task-iam.tf
+++ b/rds-infrastructure-tooling-task-iam.tf
@@ -107,6 +107,21 @@ resource "aws_iam_role_policy_attachment" "infrastructure_rds_s3_backups_task_s3
   policy_arn = aws_iam_policy.infrastructure_rds_s3_backups_task_s3_list[each.key].arn
 }
 
+resource "aws_iam_policy" "infrastructure_rds_tooling_task_ssm_create_channels" {
+  for_each = local.enable_infrastructure_rds_tooling ? local.infrastructure_rds : {}
+
+  name        = "${local.resource_prefix}-${substr(sha512("rds-tooling-task-${each.key}-ssm-create-channels"), 0, 6)}"
+  description = "${local.resource_prefix}-rds-tooling-task-${each.key}-ssm-create-channels"
+  policy      = templatefile("${path.root}/policies/ssm-create-channels.json.tpl", {})
+}
+
+resource "aws_iam_role_policy_attachment" "infrastructure_rds_tooling_task_ssm_create_channels" {
+  for_each = local.enable_infrastructure_rds_tooling ? local.infrastructure_rds : {}
+
+  role       = aws_iam_role.infrastructure_rds_tooling_task[each.key].name
+  policy_arn = aws_iam_policy.infrastructure_rds_tooling_task_ssm_create_channels[each.key].arn
+}
+
 resource "aws_iam_policy" "infrastructure_rds_tooling_task_kms_encrypt" {
   for_each = local.enable_infrastructure_rds_tooling && local.infrastructure_kms_encryption ? local.infrastructure_rds : {}
 


### PR DESCRIPTION
* The ECS Exec feature requires a task IAM role to grant containers the permissions needed for communication between the managed SSM agent (execute-command agent) and the SSM service
* This adds the `ssm-create-channels` to the RDS Tooling ECS task role