### PR TITLE
Fix: Add S3 logging and KMS permissions to RDS tooling ECS task role

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ This project creates and manages resources within an AWS account for infrastruct
 | [aws_iam_policy.infrastructure_rds_tooling_image_codebuild_allow_builds](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.infrastructure_rds_tooling_image_codebuild_cloudwatch_rw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.infrastructure_rds_tooling_image_codebuild_ecr_push](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.infrastructure_rds_tooling_task_ecs_exec_log_kms_decrypt](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.infrastructure_rds_tooling_task_ecs_exec_log_s3_write](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.infrastructure_rds_tooling_task_execution_cloudwatch_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.infrastructure_rds_tooling_task_execution_ecr_pull](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.infrastructure_rds_tooling_task_execution_get_secret_value](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
@@ -286,6 +288,8 @@ This project creates and manages resources within an AWS account for infrastruct
 | [aws_iam_role_policy_attachment.infrastructure_rds_tooling_image_codebuild_allow_builds](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.infrastructure_rds_tooling_image_codebuild_cloudwatch_rw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.infrastructure_rds_tooling_image_codebuild_ecr_push](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.infrastructure_rds_tooling_task_ecs_exec_log_kms_decrypt](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.infrastructure_rds_tooling_task_ecs_exec_log_s3_write](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.infrastructure_rds_tooling_task_execution_cloudwatch_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.infrastructure_rds_tooling_task_execution_ecr_pull](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.infrastructure_rds_tooling_task_execution_get_secret_value](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |

--- a/rds-infrastructure-tooling-task-iam.tf
+++ b/rds-infrastructure-tooling-task-iam.tf
@@ -122,6 +122,41 @@ resource "aws_iam_role_policy_attachment" "infrastructure_rds_tooling_task_ssm_c
   policy_arn = aws_iam_policy.infrastructure_rds_tooling_task_ssm_create_channels[each.key].arn
 }
 
+resource "aws_iam_policy" "infrastructure_rds_tooling_task_ecs_exec_log_s3_write" {
+  for_each = local.enable_infrastructure_rds_tooling ? local.infrastructure_rds : {}
+
+  name        = "${local.resource_prefix}-${substr(sha512("rds-tooling-task-${each.key}-ecs-exec-log-s3-write"), 0, 6)}"
+  description = "${local.resource_prefix}-rds-tooling-task-${each.key}-ecs-exec-log-s3-write"
+  policy = templatefile("${path.root}/policies/s3-object-write.json.tpl", {
+    bucket_arn = aws_s3_bucket.infrastructure_logs[0].arn
+    path       = "/ecs-exec/*"
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "infrastructure_rds_tooling_task_ecs_exec_log_s3_write" {
+  for_each = local.enable_infrastructure_rds_tooling ? local.infrastructure_rds : {}
+
+  role       = aws_iam_role.infrastructure_rds_tooling_task[each.key].name
+  policy_arn = aws_iam_policy.infrastructure_rds_tooling_task_ecs_exec_log_s3_write[each.key].arn
+}
+
+resource "aws_iam_policy" "infrastructure_rds_tooling_task_ecs_exec_log_kms_decrypt" {
+  for_each = local.enable_infrastructure_rds_tooling ? local.infrastructure_rds : {}
+
+  name        = "${local.resource_prefix}-${substr(sha512("rds-tooling-task-${each.key}-ecs-exec-log-kms-decrypt"), 0, 6)}"
+  description = "${local.resource_prefix}-rds-tooling-task-${each.key}-ecs-exec-log-kms-decrypt"
+  policy = templatefile("${path.root}/policies/kms-decrypt.json.tpl", {
+    kms_key_arn = aws_kms_key.infrastructure[0].arn
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "infrastructure_rds_tooling_task_ecs_exec_log_kms_decrypt" {
+  for_each = local.enable_infrastructure_rds_tooling ? local.infrastructure_rds : {}
+
+  role       = aws_iam_role.infrastructure_rds_tooling_task[each.key].name
+  policy_arn = aws_iam_policy.infrastructure_rds_tooling_task_ecs_exec_log_kms_decrypt[each.key].arn
+}
+
 resource "aws_iam_policy" "infrastructure_rds_tooling_task_kms_encrypt" {
   for_each = local.enable_infrastructure_rds_tooling && local.infrastructure_kms_encryption ? local.infrastructure_rds : {}
 


### PR DESCRIPTION
* When using ECS Exec on a container, the cluster is configured to send the access logs to the logging S3 bucket (which is encrypted with KMS)
* This adds the required permissions to the 'rds-tooling' task role, to allow it to send the logs to the S3 bucket