### PR TITLE
Fix RDS Backups scheduled task container name

### DIFF
--- a/rds-infrastructure-s3-backups-scheduled-task.tf
+++ b/rds-infrastructure-s3-backups-scheduled-task.tf
@@ -66,7 +66,7 @@ resource "aws_cloudwatch_event_target" "infrastructure_rds_s3_backups_scheduled_
   input = jsonencode({
     containerOverrides = [
       {
-        name = "rds-tooling${each.key}",
+        name = "rds-tooling-${each.key}",
         command = ["/bin/bash", "-c", templatefile(
           local.rds_s3_backups_container_entrypoint_file[each.value["engine"]],
           {


### PR DESCRIPTION
* The `containerOverrides` container name was missing a hyphen, meanaing that the scheduled task couldn't run (because it couldn't find the defined container to add the overrides)