### PR TITLE
Fix: RDS tooling role requires KMS decrypt

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ This project creates and manages resources within an AWS account for infrastruct
 | [aws_iam_policy.infrastructure_rds_tooling_task_ecs_exec_log_s3_write](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.infrastructure_rds_tooling_task_execution_cloudwatch_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.infrastructure_rds_tooling_task_execution_ecr_pull](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.infrastructure_rds_tooling_task_execution_ecs_get_secret_value_kms_decrypt](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.infrastructure_rds_tooling_task_execution_get_secret_value](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.infrastructure_rds_tooling_task_kms_encrypt](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.infrastructure_rds_tooling_task_ssm_create_channels](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
@@ -292,6 +293,7 @@ This project creates and manages resources within an AWS account for infrastruct
 | [aws_iam_role_policy_attachment.infrastructure_rds_tooling_task_ecs_exec_log_s3_write](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.infrastructure_rds_tooling_task_execution_cloudwatch_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.infrastructure_rds_tooling_task_execution_ecr_pull](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.infrastructure_rds_tooling_task_execution_ecs_get_secret_value_kms_decrypt](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.infrastructure_rds_tooling_task_execution_get_secret_value](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.infrastructure_rds_tooling_task_kms_encrypt](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.infrastructure_rds_tooling_task_ssm_create_channels](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |

--- a/rds-infrastructure-cluster.tf
+++ b/rds-infrastructure-cluster.tf
@@ -16,7 +16,7 @@ resource "aws_rds_cluster" "infrastructure_rds" {
   preferred_maintenance_window        = "mon:19:00-mon:22:00"
   master_username                     = "root"
   manage_master_user_password         = true
-  master_user_secret_kms_key_id       = each.value["dedicated_kms_key"] == true ? aws_kms_key.infrastructure_rds[each.key].key_id : null
+  master_user_secret_kms_key_id       = each.value["dedicated_kms_key"] == true ? aws_kms_key.infrastructure_rds[each.key].key_id : local.infrastructure_kms_encryption ? aws_kms_key.infrastructure[0].key_id : null
   iam_database_authentication_enabled = null
   deletion_protection                 = false
   enable_http_endpoint                = false

--- a/rds-infrastructure-instance.tf
+++ b/rds-infrastructure-instance.tf
@@ -54,7 +54,7 @@ resource "aws_db_instance" "infrastructure_rds" {
   db_name                       = null
   username                      = "root"
   manage_master_user_password   = true
-  master_user_secret_kms_key_id = each.value["dedicated_kms_key"] == true ? aws_kms_key.infrastructure_rds[each.key].key_id : null
+  master_user_secret_kms_key_id = each.value["dedicated_kms_key"] == true ? aws_kms_key.infrastructure_rds[each.key].key_id : local.infrastructure_kms_encryption ? aws_kms_key.infrastructure[0].key_id : null
   character_set_name            = null
   timezone                      = null
   deletion_protection           = false


### PR DESCRIPTION
* If the RDS is configured to use a dedicated KMS key, we have configured it so that the same key is used to encrypt the RDS Secret Value for the password.
* This adds a policy to the task execution role to allow decrypting with the KMS key
* This change also adds the infrastructure KMS key as the encryption key if the RDS is not configured to use a dedicated KMS key