### PR TITLE
Add empty filter to S3 lifecycle rules

### DIFF
--- a/ecs-cluster-infrastructure-service-build-pipeline-s3-artifact-store.tf
+++ b/ecs-cluster-infrastructure-service-build-pipeline-s3-artifact-store.tf
@@ -94,6 +94,10 @@ resource "aws_s3_bucket_lifecycle_configuration" "infrastructure_ecs_cluster_ser
       storage_class = "GLACIER"
     }
 
+    filter {
+      prefix = ""
+    }
+
     status = "Enabled"
   }
 }

--- a/s3-custom-buckets.tf
+++ b/s3-custom-buckets.tf
@@ -116,6 +116,10 @@ resource "aws_s3_bucket_lifecycle_configuration" "custom" {
       storage_class = "STANDARD_IA"
     }
 
+    filter {
+      prefix = ""
+    }
+
     status = "Disabled"
   }
 
@@ -127,6 +131,10 @@ resource "aws_s3_bucket_lifecycle_configuration" "custom" {
       transition {
         days          = each.value["transition_to_ia_days"]
         storage_class = "STANDARD_IA"
+      }
+
+      filter {
+        prefix = ""
       }
 
       status = "Enabled"
@@ -141,6 +149,10 @@ resource "aws_s3_bucket_lifecycle_configuration" "custom" {
       transition {
         days          = each.value["transition_to_glacier_days"]
         storage_class = "GLACIER"
+      }
+
+      filter {
+        prefix = ""
       }
 
       status = "Enabled"

--- a/s3-infrastructure-logs.tf
+++ b/s3-infrastructure-logs.tf
@@ -92,12 +92,12 @@ resource "aws_s3_bucket_lifecycle_configuration" "logs" {
   rule {
     id = "all_expire"
 
-    filter {
-      prefix = ""
-    }
-
     expiration {
       days = local.infrastructure_logging_bucket_retention
+    }
+
+    filter {
+      prefix = ""
     }
 
     status = "Enabled"


### PR DESCRIPTION
* A warning is thrown if a filter is not set: 
  
  ``` │ Warning: Invalid Attribute Combination │
  │   with aws_s3_bucket_lifecycle_configuration.infrastructure_ecs_cluster_service_build_pipeline_artifact_store,
  │   on ecs-cluster-infrastructure-service-build-pipeline-s3-artifact-store.tf line 79, in resource "aws_s3_bucket_lifecycle_configuration" "infrastructure_ecs_cluster_service_build_pipeline_artifact_store":
  │   79: resource "aws_s3_bucket_lifecycle_configuration" "infrastructure_ecs_cluster_service_build_pipeline_artifact_store" {
  │
  │ No attribute specified when one (and only one) of [rule[0].filter,rule[0].prefix] is required
  │
  │ This will be an error in a future version of the provider
  │
  │ (and one more similar warning elsewhere)
  ╵
  ```
* https://github.com/hashicorp/terraform-provider-aws/issues/41710