### PR TITLE
Fix custom S3 bucket cloudfront certificate

### DIFF
--- a/s3-custom-buckets-cloudfront.tf
+++ b/s3-custom-buckets-cloudfront.tf
@@ -13,7 +13,7 @@ resource "aws_cloudfront_distribution" "custom_s3_buckets" {
 
   viewer_certificate {
     acm_certificate_arn            = each.value["cloudfront_decicated_distribution_tls_certificate_arn"] != null ? each.value["cloudfront_decicated_distribution_tls_certificate_arn"] : local.enable_infrastructure_wildcard_certificate ? aws_acm_certificate_validation.infrastructure_wildcard_us_east_1[0].certificate_arn : null
-    cloudfront_default_certificate = local.enable_infrastructure_wildcard_certificate && each.value["cloudfront_decicated_distribution_tls_certificate_arn"] != null ? null : true
+    cloudfront_default_certificate = local.enable_infrastructure_wildcard_certificate || each.value["cloudfront_decicated_distribution_tls_certificate_arn"] != null ? null : true
     minimum_protocol_version       = local.enable_infrastructure_wildcard_certificate || each.value["cloudfront_decicated_distribution_tls_certificate_arn"] != null ? "TLSv1.2_2021" : null
     ssl_support_method             = "sni-only"
   }


### PR DESCRIPTION
* Fixes the condition, so that the default certificate is only used if one hasn't been provided.
* It was attempting to set the `cloudfront_default_certificate` to true, if it was using the infrastructure wildcard certificate - which just adds a 1 minute delay to every deploy (because CloudFront correctly doesn't set it to `true`, but silently fails)