### PR TITLE
Network Firewall domain filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ This project creates and manages resources within an AWS account for infrastruct
 | [aws_cloudwatch_log_group.ecs_cluster_infrastructure_ecs_asg_diff_metric_lambda_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.ecs_cluster_infrastructure_instance_refresh_lambda_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.ecs_cluster_infrastructure_pending_task_metric_lambda_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_cloudwatch_log_group.egress_domain_filtering](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.infrastructure_ecs_cluster_datadog_agent](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.infrastructure_ecs_cluster_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.infrastructure_rds_exports](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
@@ -335,6 +336,10 @@ This project creates and manages resources within an AWS account for infrastruct
 | [aws_network_acl_rule.ingress_allow_all_public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.ingress_private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.ingress_public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
+| [aws_networkfirewall_firewall.egress_domain_filtering](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/networkfirewall_firewall) | resource |
+| [aws_networkfirewall_firewall_policy.egress_domain_filtering](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/networkfirewall_firewall_policy) | resource |
+| [aws_networkfirewall_logging_configuration.egress_domain_filtering](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/networkfirewall_logging_configuration) | resource |
+| [aws_networkfirewall_rule_group.egress_domain_filtering](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/networkfirewall_rule_group) | resource |
 | [aws_placement_group.infrastructure_ecs_cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/placement_group) | resource |
 | [aws_rds_cluster.infrastructure_rds](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster) | resource |
 | [aws_rds_cluster_instance.infrastructure_rds](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster_instance) | resource |
@@ -600,6 +605,7 @@ This project creates and manages resources within an AWS account for infrastruct
 | <a name="input_infrastructure_vpc"></a> [infrastructure\_vpc](#input\_infrastructure\_vpc) | Enable infrastructure VPC | `bool` | n/a | yes |
 | <a name="input_infrastructure_vpc_assign_generated_ipv6_cidr_block"></a> [infrastructure\_vpc\_assign\_generated\_ipv6\_cidr\_block](#input\_infrastructure\_vpc\_assign\_generated\_ipv6\_cidr\_block) | Assign generated IPv6 CIDR block on infrastructure VPC | `bool` | n/a | yes |
 | <a name="input_infrastructure_vpc_cidr_block"></a> [infrastructure\_vpc\_cidr\_block](#input\_infrastructure\_vpc\_cidr\_block) | Infrastructure VPC CIDR block | `string` | n/a | yes |
+| <a name="input_infrastructure_vpc_egress_domain_filtering_allow_list"></a> [infrastructure\_vpc\_egress\_domain\_filtering\_allow\_list](#input\_infrastructure\_vpc\_egress\_domain\_filtering\_allow\_list) | List of domains to allow outbout, using AWS Network firewall. If empty, domain filtering will not be applied | `list(string)` | n/a | yes |
 | <a name="input_infrastructure_vpc_enable_dns_hostnames"></a> [infrastructure\_vpc\_enable\_dns\_hostnames](#input\_infrastructure\_vpc\_enable\_dns\_hostnames) | Enable DNS hostnames on infrastructure VPC | `bool` | n/a | yes |
 | <a name="input_infrastructure_vpc_enable_dns_support"></a> [infrastructure\_vpc\_enable\_dns\_support](#input\_infrastructure\_vpc\_enable\_dns\_support) | Enable DNS support on infrastructure VPC | `bool` | n/a | yes |
 | <a name="input_infrastructure_vpc_enable_network_address_usage_metrics"></a> [infrastructure\_vpc\_enable\_network\_address\_usage\_metrics](#input\_infrastructure\_vpc\_enable\_network\_address\_usage\_metrics) | Enable network address usage metrics on infrastructure VPC | `bool` | n/a | yes |

--- a/locals.tf
+++ b/locals.tf
@@ -100,6 +100,8 @@ locals {
   infrastructure_vpc_network_acl_egress_custom_rules_public   = var.infrastructure_vpc_network_acl_egress_custom_rules_public
   infrastructure_vpc_network_acl_ingress_lockdown_public      = var.infrastructure_vpc_network_acl_ingress_lockdown_public
   infrastructure_vpc_network_acl_ingress_custom_rules_public  = var.infrastructure_vpc_network_acl_ingress_custom_rules_public
+  infrastructure_vpc_egress_domain_filtering_allow_list       = var.infrastructure_vpc_egress_domain_filtering_allow_list
+  infrastructure_vpc_enable_egress_domain_filtering           = length(local.infrastructure_vpc_egress_domain_filtering_allow_list) > 0
   infrastructure_vpc_flow_logs_cloudwatch_logs                = var.infrastructure_vpc_flow_logs_cloudwatch_logs && local.infrastructure_vpc
   infrastructure_vpc_flow_logs_s3_with_athena                 = var.infrastructure_vpc_flow_logs_s3_with_athena && local.infrastructure_vpc
   infrastructure_vpc_flow_logs_s3_key_prefix                  = trim(var.infrastructure_vpc_flow_logs_s3_key_prefix, "/")

--- a/network-firewall-rules/domain-filtering.tpl
+++ b/network-firewall-rules/domain-filtering.tpl
@@ -1,0 +1,8 @@
+%{ for idx, domain in domains ~}
+pass tls any any -> any any (msg:"Allow ${domain}"; tls.sni; content:"${domain}"; endswith; sid:${idx}; rev:1;)
+%{ endfor ~}
+drop tls any any -> any any (msg:"Drop other TLS"; sid:${length(domains)}; rev:1;)
+%{ for idx, domain in domains ~}
+pass http any any -> any any (msg:"Allow ${domain} HTTP"; http.host; content:"${domain}"; endswith; sid:${length(domains) + idx}; rev:1;)
+%{ endfor ~}
+drop http any any -> any any (msg:"Drop other HTTP"; sid:${length(domains) + length(domains)}; rev:1;)

--- a/variables.tf
+++ b/variables.tf
@@ -221,6 +221,11 @@ variable "infrastructure_vpc_network_acl_ingress_custom_rules_public" {
   }))
 }
 
+variable "infrastructure_vpc_egress_domain_filtering_allow_list" {
+  description = "List of domains to allow outbout, using AWS Network firewall. If empty, domain filtering will not be applied"
+  type        = list(string)
+}
+
 variable "enable_infrastructure_vpc_transfer_s3_bucket" {
   description = "Enable VPC transfer S3 bucket. This allows uploading/downloading files from resources within the infrastructure VPC"
   type        = bool

--- a/vpc-infrastructure-domain-filtering.tf
+++ b/vpc-infrastructure-domain-filtering.tf
@@ -1,0 +1,67 @@
+resource "aws_networkfirewall_rule_group" "egress_domain_filtering" {
+  count = local.infrastructure_vpc_enable_egress_domain_filtering ? 1 : 0
+
+  capacity = 100
+  name     = "${local.resource_prefix}-infrastructure-egress-domain-filtering"
+  type     = "STATEFUL"
+
+  rule_group {
+    rules_source {
+      rules_string = templatefile(
+        "${path.root}/network-firewall-rules/domain-filtering.tpl",
+        {
+          domains = local.infrastructure_vpc_egress_domain_filtering_allow_list
+        }
+      )
+    }
+  }
+}
+
+resource "aws_networkfirewall_firewall_policy" "egress_domain_filtering" {
+  count = local.infrastructure_vpc_enable_egress_domain_filtering ? 1 : 0
+
+  name = "${local.resource_prefix}-infrastructure-egress-domain-filtering"
+
+  stateless_default_actions          = ["aws:forward_to_sfe"]
+  stateless_fragment_default_actions = ["aws:forward_to_sfe"]
+
+  stateful_rule_group_reference {
+    resource_arn = aws_networkfirewall_rule_group.egress_domain_filtering[0].arn
+  }
+}
+
+resource "aws_networkfirewall_firewall" "egress_domain_filtering" {
+  count = local.infrastructure_vpc_enable_egress_domain_filtering ? 1 : 0
+
+  name                = "${local.resource_prefix}-infrastructure-egress-domain-filtering"
+  firewall_policy_arn = aws_networkfirewall_firewall_policy.egress_domain_filtering[0].arn
+  vpc_id              = aws_vpc.infrastructure[0].id
+
+  dynamic "subnet_mapping" {
+    for_each = local.infrastructure_vpc_network_enable_private ? [for subnet in aws_subnet.infrastructure_private : subnet.id] : local.infrastructure_vpc_network_enable_public ? [for subnet in aws_subnet.infrastructure_public : subnet.id] : null
+    content {
+      subnet_id = subnet_mapping.value
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_group" "egress_domain_filtering" {
+  count = local.infrastructure_vpc_enable_egress_domain_filtering ? 1 : 0
+
+  name = "/aws/network-firewall/${local.resource_prefix}-infrastructure-egress-domain-filtering"
+}
+
+resource "aws_networkfirewall_logging_configuration" "egress_domain_filtering" {
+  count = local.infrastructure_vpc_enable_egress_domain_filtering ? 1 : 0
+
+  firewall_arn = aws_networkfirewall_firewall.egress_domain_filtering[0].arn
+
+  logging_configuration {
+    log_destination_config {
+      log_type = "FLOW"
+      log_destination = {
+        logGroup = aws_cloudwatch_log_group.egress_domain_filtering[0].name
+      }
+    }
+  }
+}


### PR DESCRIPTION
* Adds the ability to provide a list of domains, which will be used to create Network Firewall rules, which will only allow egress traffic to those domains, based on SNI or HTTP header
* This creates an endpoint on each of the private or public subnets