### PR TITLE
Fix the invalid index when creating security group rules for elasticache

### DIFF
--- a/elasticache-infrastructure-security-group.tf
+++ b/elasticache-infrastructure-security-group.tf
@@ -20,7 +20,7 @@ resource "aws_security_group_rule" "infrastructure_elasticache_ingress_tcp_ecs_i
 }
 
 resource "aws_security_group_rule" "infrastructure_elasticache_ingress_tcp_custom_lambda" {
-  for_each = local.infrastructure_vpc_network_enable_public || local.infrastructure_vpc_network_enable_private ? [
+  for_each = (local.infrastructure_vpc_network_enable_public || local.infrastructure_vpc_network_enable_private) && length(local.infrastructure_elasticache) > 0 ? [
     for elasticache_k, elasticache_v in local.infrastructure_elasticache : {
       for lambda_k, lambda_v in local.custom_lambda_functions : "${elasticache_k}_${lambda_k}" => merge(elasticache_v, { lambda_source_security_group = aws_security_group.custom_lambda[lambda_k].id }) if lambda_v["launch_in_infrastructure_vpc"] == true
     }


### PR DESCRIPTION
This fixes:
```
╷
│ Error: Invalid index
│
│   on elasticache-infrastructure-security-group.tf line 27, in resource "aws_security_group_rule" "infrastructure_elasticache_ingress_tcp_custom_lambda":
│   27:   ][0] : {}
│     ├────────────────
│     │ aws_security_group.custom_lambda is object with no attributes
│     │ local.custom_lambda_functions is empty map of object
│     │ local.infrastructure_elasticache is object with no attributes
│
│ The given key does not identify an element in this collection value:
│ the collection has no elements.
╵
```